### PR TITLE
feat: add authentication utility

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -8,6 +8,7 @@ from fastapi.templating import Jinja2Templates
 from sqlalchemy.ext.asyncio import AsyncSession
 import pathlib
 
+from app.utils.auth import require_dashboard_auth, _auth_configured
 from app.db.database import init_db, get_db
 from app.github.client import GitHubClient
 from app.config.loader import ConfigLoader
@@ -41,6 +42,11 @@ async def lifespan(app: FastAPI):
 
     if settings.is_production:
         _scheduler.start()
+        if not _auth_configured():
+            log.warning(
+                "DASHBOARD_USERNAME/DASHBOARD_PASSWORD are unset in production -"
+                "dashboard and /api/v1/* are UNAUTHENTICATED."
+            )
 
     log.info("Bot ready on port %d", settings.port)
     yield
@@ -59,10 +65,11 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
-app.include_router(api_router)
+app.include_router(api_router, dependencies=[Depend(require_dashboard_auth)])
 
 
 # ── Webhook endpoint ──────────────────────────────────────────
+
 
 @app.post("/webhook")
 async def webhook(request: Request, db: AsyncSession = Depends(get_db)):
@@ -73,12 +80,14 @@ async def webhook(request: Request, db: AsyncSession = Depends(get_db)):
 
 # ── Dashboard ─────────────────────────────────────────────────
 
+
 @app.get("/", response_class=HTMLResponse)
-async def dashboard(request: Request):
+async def dashboard(request: Request, _auth: None = Depends(require_dashboard_auth)):
     return templates.TemplateResponse("dashboard.html", {"request": request})
 
 
 # ── Health ────────────────────────────────────────────────────
+
 
 @app.get("/healthz")
 async def healthz():

--- a/app/main.py
+++ b/app/main.py
@@ -65,7 +65,7 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
-app.include_router(api_router, dependencies=[Depend(require_dashboard_auth)])
+app.include_router(api_router, dependencies=[Depends(require_dashboard_auth)])
 
 
 # ── Webhook endpoint ──────────────────────────────────────────

--- a/app/utils/auth.py
+++ b/app/utils/auth.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+import hmac
+from fastapi import Depends, HTTPException
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
+from app.utils.settings import settings
+from app.utils.logger import get_logger
+
+log = get_logger("utils.auth")
+_security = HTTPBasic(auto_error=False)
+
+
+def _auth_configured() -> bool:
+    return bool(settings.dashboard_username and settings.dashboard_password)
+
+
+async def require_dashboard_auth(
+    credentials: HTTPBasicCredentials | None = Depends(_security),
+) -> None:
+    if not _auth_configured():
+        return
+
+    unauthorized = HTTPException(
+        status_code=401,
+        detail="Unauthorized",
+        headers={"WWW-Authenticate": "Basic"},
+    )
+    if credentials is None:
+        raise unauthorized
+
+    user_ok = hmac.compare_digest(credentials.username, settings.dashboard_username)
+    pass_ok = hmac.compare_digest(credentials.password, settings.dashboard_password)
+    if not (user_ok and pass_ok):
+        raise unauthorized


### PR DESCRIPTION
## Summary

This PR implements HTTP Basic Authentication for the dashboard (`/`) and all `/api/v1/*` endpoints when dashboard credentials are configured, while preserving the existing development workflow when credentials are not set.

## Changes

* Added a reusable `require_dashboard_auth` dependency in `app/utils/auth.py`.
* Added an internal `_auth_configured()` helper to determine whether dashboard authentication is enabled.
* Protected the dashboard (`GET /`) by applying the `require_dashboard_auth` dependency.
* Applied the same authentication dependency to all `/api/v1/*` routes through the API router.
* Added a startup warning in production when `DASHBOARD_USERNAME` and `DASHBOARD_PASSWORD` are not configured, making unauthenticated deployments explicit instead of silent.

## Behavior

### When dashboard credentials are configured

* `GET /` requires valid HTTP Basic Authentication.
* All `/api/v1/*` endpoints require valid HTTP Basic Authentication.
* Credentials are validated using `hmac.compare_digest()` for constant-time comparison.

### When dashboard credentials are not configured

* Authentication remains disabled to support local development.
* In production (`settings.is_production`), a warning is logged during application startup indicating that the dashboard and API endpoints are unauthenticated.

## Files Changed

* `app/utils/auth.py`
* `app/main.py`

## Closes

Closes #13.
