### PR TITLE
feat: webhook replay protection and delivery skew check

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,6 @@ ENVIRONMENT=development
 #  Dashboard auth (leave blank to disable) 
 DASHBOARD_USERNAME=
 DASHBOARD_PASSWORD=
+
+# Optional: max allowed webhook delivery age, in seconds
+WEBHOOK_MAX_SKEW_SECONDS=300

--- a/app/github/replay_guard.py
+++ b/app/github/replay_guard.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from cachetools import TTLCache
+
+_DELIVERY_TTL_SECONDS = 600  # 10 minutes
+_seen_deliveries: TTLCache = TTLCache(maxsize=10_000, ttl=_DELIVERY_TTL_SECONDS)
+
+
+def is_replay(delivery_id: str) -> bool:
+    if not delivery_id:
+        return False
+    if delivery_id in _seen_deliveries:
+        return True
+    _seen_deliveries[delivery_id] = True
+    return False

--- a/app/github/webhooks.py
+++ b/app/github/webhooks.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import time  # #5
 from typing import Any
 
 from fastapi import HTTPException, Request
@@ -11,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config.loader import ConfigLoader
 from app.github.client import GitHubClient
+from app.github.replay_guard import is_replay  # #4
 from app.utils.logger import get_logger
 from app.utils.settings import settings
 from app.workflows.issuemanagement import IssueManagementWorkflow
@@ -43,6 +45,32 @@ class WebhookRouter:
         # Signature verification
         if settings.github_webhook_secret:
             self._verify_signature(request, await request.body())
+
+        # #4 — replay protection: reject deliveries we've already processed
+        delivery_id = request.headers.get("X-GitHub-Delivery", "")
+        if delivery_id and is_replay(delivery_id):
+            log.warning("Rejected replayed delivery %s", delivery_id)
+            raise HTTPException(status_code=409, detail="Duplicate delivery")
+
+        # #5 — skew check, defense-in-depth (secondary to signature + replay ID)
+        date_header = request.headers.get("Date")
+        if date_header:
+            try:
+                from email.utils import parsedate_to_datetime
+
+                sent_at = parsedate_to_datetime(date_header).timestamp()
+                skew = abs(time.time() - sent_at)
+                if skew > settings.webhook_max_skew_seconds:
+                    log.warning(
+                        "Webhook delivery %s exceeded max skew (%.0fs)",
+                        delivery_id,
+                        skew,
+                    )
+                    raise HTTPException(
+                        status_code=401, detail="Delivery timestamp out of range"
+                    )
+            except (TypeError, ValueError):
+                pass  # unparseable Date header — skip, don't fail the request
 
         event = request.headers.get("X-GitHub-Event", "")
         payload: dict[str, Any] = await request.json()

--- a/app/main.py
+++ b/app/main.py
@@ -18,6 +18,7 @@ from app.github.webhooks import WebhookRouter
 from app.scheduler.jobs import BotScheduler
 from app.utils.logger import get_logger
 from app.utils.settings import settings
+from app.utils.auth import require_dashboard_auth, _auth_configured
 
 log = get_logger("main")
 

--- a/app/main.py
+++ b/app/main.py
@@ -16,9 +16,9 @@ from app.db.database import get_db, init_db
 from app.github.client import GitHubClient
 from app.github.webhooks import WebhookRouter
 from app.scheduler.jobs import BotScheduler
+from app.utils.auth import _auth_configured, require_dashboard_auth
 from app.utils.logger import get_logger
 from app.utils.settings import settings
-from app.utils.auth import require_dashboard_auth, _auth_configured
 
 log = get_logger("main")
 

--- a/app/utils/settings.py
+++ b/app/utils/settings.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -16,7 +14,7 @@ class Settings(BaseSettings):
     github_app_id: str = ""
     github_private_key: str = ""
     github_webhook_secret: str = ""
-    github_webhook_secret_old: Optional[str] = None
+    github_webhook_secret_old: str | None = None
     webhook_max_skew_seconds: int = 300
 
     # Anthropic

--- a/app/utils/settings.py
+++ b/app/utils/settings.py
@@ -2,16 +2,22 @@
 
 from __future__ import annotations
 
+from typing import Optional
+
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
-    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
+    model_config = SettingsConfigDict(
+        env_file=".env", env_file_encoding="utf-8", extra="ignore"
+    )
 
     # GitHub App
     github_app_id: str = ""
     github_private_key: str = ""
     github_webhook_secret: str = ""
+    github_webhook_secret_old: Optional[str] = None
+    webhook_max_skew_seconds: int = 300
 
     # Anthropic
     anthropic_api_key: str | None = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 asyncpg==0.29.0
+cachetools==5.5.0
 fastapi==0.115.5
 uvicorn[standard]==0.32.1
 pydantic==2.10.3

--- a/tests/unit/test_onboarding.py
+++ b/tests/unit/test_onboarding.py
@@ -3,6 +3,8 @@
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock
 
+import pytest
+
 from app.workflows.onboarding import OnboardingWorkflow
 
 


### PR DESCRIPTION
## Summary
Implements Month 1 security hardening sub-issues #16, #17 and #14.
Closes #14 
Closes #16
Closes #17

## Changes
- `app/github/replay_guard.py` (new) — TTL cache (10 min) keyed on
  `X-GitHub-Delivery`, rejects duplicate deliveries with a 409
- `app/github/webhooks.py` — wires the replay check and an optional
  `Date`-header-based skew check into `WebhookRouter.handle()`, both
  running right after signature verification
- `app/utils/settings.py` — new `webhook_max_skew_seconds` setting
  (default 300s)
- `.env.example` — documents `WEBHOOK_MAX_SKEW_SECONDS`
- `requirements.txt` — adds `cachetools==5.5.0`
- `app/main.py` — fixes a missing import (`require_dashboard_auth`,
  `_auth_configured`) needed for #14's dashboard/API auth to actually
  load
- `tests/unit/test_onboarding.py` — restores a `pytest` import
  accidentally stripped by a prior `ruff --fix` run

## Notes
- Replay cache is in-memory/per-instance — fine for the current
  single-instance deployment; will need to move to Redis/DB once this
  runs multi-instance (tracked separately for the multi-forge phase)
- Skew check is explicitly secondary defense-in-depth — GitHub doesn't
  sign a delivery timestamp, so this only fires when a `Date` header
  is present (e.g. behind a proxy). Signature verification + the
  delivery-ID replay check above are the primary controls.

## Testing
- `python -m pytest tests/unit/ tests/integration/ -q` — 76 passed
- Manually verified: same delivery ID sent twice → second request 409s