### PR TITLE
chore: fix remaining Ruff lint violations and modernize UTC timestamp handling

### DIFF
--- a/app/db/models.py
+++ b/app/db/models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy import JSON, Boolean, DateTime, Float, Index, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
@@ -14,7 +14,11 @@ class AuditLog(Base):
     __tablename__ = "audit_logs"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    timestamp: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, index=True)
+    timestamp: Mapped[datetime] = mapped_column(
+        DateTime,
+        default=lambda: datetime.now(timezone.utc),
+        index=True,
+    )
     action: Mapped[str] = mapped_column(String(64), index=True)
     owner: Mapped[str] = mapped_column(String(128), index=True)
     repo: Mapped[str] = mapped_column(String(128), index=True)
@@ -33,7 +37,10 @@ class PRHealthScore(Base):
     __tablename__ = "pr_health_scores"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime,
+        default=lambda: datetime.now(timezone.utc),
+    )
     owner: Mapped[str] = mapped_column(String(128), index=True)
     repo: Mapped[str] = mapped_column(String(128), index=True)
     pr_number: Mapped[int] = mapped_column(Integer)
@@ -56,7 +63,7 @@ class ContributorSnapshot(Base):
     __tablename__ = "contributor_snapshots"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    recorded_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    recorded_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
     owner: Mapped[str] = mapped_column(String(128), index=True)
     repo: Mapped[str] = mapped_column(String(128), index=True)
     login: Mapped[str] = mapped_column(String(128), index=True)
@@ -71,7 +78,7 @@ class StaleActionLog(Base):
     __tablename__ = "stale_action_logs"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    occurred_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    occurred_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
     owner: Mapped[str] = mapped_column(String(128))
     repo: Mapped[str] = mapped_column(String(128))
     issue_number: Mapped[int] = mapped_column(Integer)
@@ -87,7 +94,7 @@ class ReviewerRecommendation(Base):
     __tablename__ = "reviewer_recommendations"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
     owner: Mapped[str] = mapped_column(String(128))
     repo: Mapped[str] = mapped_column(String(128))
     pr_number: Mapped[int] = mapped_column(Integer)

--- a/app/github/webhooks.py
+++ b/app/github/webhooks.py
@@ -130,8 +130,13 @@ class WebhookRouter:
             else:
                 log.debug("No handler for event=%s", event)
 
-        except Exception as exc:
-            log.exception("Error in %s handler for %s/%s: %s", event, owner, repo, exc)
+        except Exception:
+            log.exception(
+                "Error in %s handler for %s/%s",
+                event,
+                owner,
+                repo,
+            )
 
     #  Event handlers
 

--- a/app/utils/audit.py
+++ b/app/utils/audit.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -46,7 +46,7 @@ async def record(
         raise ValueError(f"Unknown audit action: {action!r}")
 
     entry = AuditLog(
-        timestamp=datetime.utcnow(),
+        timestamp=datetime.now(timezone.utc),
         action=action,
         owner=owner,
         repo=repo,

--- a/tests/unit/test_audit.py
+++ b/tests/unit/test_audit.py
@@ -53,13 +53,24 @@ async def test_multiple_records_stored(db):
 
 @pytest.mark.asyncio
 async def test_timestamp_set_automatically(db):
-    from datetime import datetime
-    before = datetime.utcnow()
-    await record(db, action="issue.assigned", owner="o", repo="r", reason="t")
+    from datetime import datetime, timezone
+    before = datetime.now(timezone.utc)
+    await record(
+        db,
+        action="issue.assigned",
+        owner="o",
+        repo="r",
+        reason="t",
+    )
     await db.commit()
     result = await db.execute(select(AuditLog))
     row = result.scalars().first()
-    assert row.timestamp >= before
+
+    timestamp = row.timestamp
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=timezone.utc)
+
+    assert timestamp >= before
 
 
 def test_valid_actions_set_is_not_empty():


### PR DESCRIPTION
## Summary

Resolves the remaining Ruff lint violations and updates the project to consistently use timezone-aware UTC timestamps.

## Changes

- Fixed `TRY401` by removing the redundant exception argument from `logging.exception()` in the webhook router.
- Replaced deprecated `datetime.utcnow()` usage with timezone-aware `datetime.now(timezone.utc)` in the audit utilities.
- Updated all ORM timestamp defaults to use timezone-aware UTC timestamps for consistency across models.
- Updated the audit timestamp test to work correctly with timezone-aware datetimes while remaining compatible with SQLite's naive datetime behavior.

## Files Updated

- `app/db/models.py`
  - Updated all timestamp defaults to use `datetime.now(timezone.utc)`.

- `app/github/webhooks.py`
  - Fixed the `logging.exception()` call to comply with Ruff `TRY401`.

- `app/utils/audit.py`
  - Replaced deprecated `datetime.utcnow()` with timezone-aware UTC timestamps.

- `tests/unit/test_audit.py`
  - Updated timestamp assertions for timezone-aware datetimes and SQLite compatibility.

## Validation

- ✅ `ruff check`
- ✅ `python -m pytest tests/unit/ tests/integration/ -q`