### PR TITLE
feat(workflows): add reviewer assignment workflow

### DIFF
--- a/.github/hiero-bot.yml
+++ b/.github/hiero-bot.yml
@@ -17,6 +17,15 @@ workflows:
       enabled: false
     auto_label: true
 
+  reviewer_assignment:
+    enabled: true
+    availability_file: ".github/reviewers.yml"
+    reviewers_count: 1
+    strategy: "round-robin"
+    exclude_pr_author: true
+    fallback_to_all_if_none_available: true
+    notify_comment: "off"
+
   pr_health:
     enabled: true
 

--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -1,0 +1,9 @@
+reviewers:
+  - login: BHUVANSH855
+    available: true
+
+  - login: mohityadav8
+    available: true
+
+  - login: member3
+    available: false

--- a/.github/scripts/check_audit_severity.py
+++ b/.github/scripts/check_audit_severity.py
@@ -76,7 +76,7 @@ def _parse_cvss_number(value: Any) -> float | None:
     try:
         if value.startswith("CVSS:4"):
             return CVSS4(value).base_score
-        if value.startswith("CVSS:3") or value.startswith("AV:"):
+        if value.startswith(("CVSS:3", "AV:")):
             # CVSS3() accepts either a bare metric string or one prefixed
             # with "CVSS:3.x/".
             return CVSS3(value).base_score

--- a/app/config/schema.py
+++ b/app/config/schema.py
@@ -9,6 +9,8 @@ from pydantic import BaseModel, Field, model_validator
 RoleLevel = Literal["contributor", "junior-committer", "committer", "maintainer"]
 FocusArea = Literal["security", "performance", "style", "logic", "tests"]
 MentorStrategy = Literal["round-robin", "least-busy", "expertise-match"]
+ReviewerAssignmentStrategy = Literal["round-robin", "random"]
+ReviewerNotifyComment = Literal["off", "mention"]
 Verdict = Literal["approve", "request_changes", "comment"]
 
 
@@ -126,6 +128,20 @@ class PRHealthConfig(BaseModel):          # NEW workflow
     comment_threshold: int = Field(default=60, ge=0, le=100)   # only comment if score < threshold
     label_healthy_above: int = Field(default=75, ge=0, le=100)
 
+class ReviewerAssignmentConfig(BaseModel):
+    enabled: bool = False
+
+    availability_file: str = ".github/reviewers.yml"
+
+    reviewers_count: int = Field(default=1, ge=1)
+
+    strategy: ReviewerAssignmentStrategy = "round-robin"
+
+    exclude_pr_author: bool = True
+
+    fallback_to_all_if_none_available: bool = True
+
+    notify_comment: ReviewerNotifyComment = "off"
 
 # Teams & Labels 
 
@@ -150,6 +166,9 @@ class WorkflowsConfig(BaseModel):
     progression: ProgressionConfig = Field(default_factory=ProgressionConfig)
     issue_management: IssueManagementConfig = Field(default_factory=IssueManagementConfig)
     pr_health: PRHealthConfig = Field(default_factory=PRHealthConfig)
+    reviewer_assignment: ReviewerAssignmentConfig = Field(
+        default_factory=ReviewerAssignmentConfig
+    )
 
 
 class RepoConfig(BaseModel):

--- a/app/github/client.py
+++ b/app/github/client.py
@@ -145,6 +145,24 @@ class GitHubClient:
         await self.post(f"/repos/{owner}/{repo}/issues/{number}/assignees",
                         installation_id, json={"assignees": assignees})
 
+    async def request_reviewers(
+        self,
+        owner: str,
+        repo: str,
+        pr_number: int,
+        reviewers: list[str],
+        installation_id: int,
+    ) -> None:
+        """Request reviews from one or more reviewers on a pull request."""
+        if not reviewers:
+            return
+
+        await self.post(
+            f"/repos/{owner}/{repo}/pulls/{pr_number}/requested_reviewers",
+            installation_id,
+            json={"reviewers": reviewers},
+        )
+
     async def remove_assignees(
         self, owner: str, repo: str, number: int,
         assignees: list[str], installation_id: int

--- a/app/github/webhooks.py
+++ b/app/github/webhooks.py
@@ -20,6 +20,7 @@ from app.workflows.onboarding import OnboardingWorkflow
 from app.workflows.prhealth import PRHealthWorkflow
 from app.workflows.progression import ProgressionWorkflow
 from app.workflows.pullrequest import PullRequestWorkflow
+from app.workflows.reviewerassignment import ReviewerAssignmentWorkflow
 
 log = get_logger("github.webhooks")
 
@@ -151,6 +152,7 @@ class WebhookRouter:
 
     async def _handle_pull_request(self, action: str, payload: dict, ctx: dict) -> None:
         wf_pr = PullRequestWorkflow(self._gh)
+        wf_reviewer = ReviewerAssignmentWorkflow(self._gh)
         wf_health = PRHealthWorkflow(self._gh)
         wf_prog = ProgressionWorkflow(self._gh)
 
@@ -160,6 +162,10 @@ class WebhookRouter:
 
         if action in ("opened", "synchronize", "reopened"):
             await wf_pr.handle_pr_opened(ctx, payload)
+
+            if action == "opened":
+                await wf_reviewer.handle_pr_opened(ctx, payload)
+
             await wf_health.score_pr(ctx, payload)
 
         elif action == "closed" and pr.get("merged"):

--- a/app/utils/audit.py
+++ b/app/utils/audit.py
@@ -23,6 +23,7 @@ VALID_ACTIONS = {
     "pr.labeled",
     "pr.closed_stale",
     "pr.reviewer_recommended",
+    "pr.reviewer_assigned",
     "contributor.mentor_assigned",
     "contributor.role_suggested",
     "contributor.welcomed",

--- a/app/workflows/reviewerassignment.py
+++ b/app/workflows/reviewerassignment.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import base64
+import random
+
+import yaml
+from pydantic import BaseModel, ValidationError
+
+from app.config.schema import ReviewerAssignmentStrategy
+from app.github.client import GitHubClient
+from app.utils import audit
+from app.utils.logger import get_logger
+
+log = get_logger("workflow.reviewerassignment")
+
+
+class Reviewer(BaseModel):
+    login: str
+    available: bool = True
+
+
+class ReviewersFile(BaseModel):
+    reviewers: list[Reviewer]
+
+
+class ReviewerAssignmentWorkflow:
+    """Automatically assign reviewers to newly opened pull requests."""
+
+    def __init__(self, gh: GitHubClient) -> None:
+        self._gh = gh
+
+    async def _load_reviewers(
+        self,
+        owner: str,
+        repo: str,
+        installation_id: int,
+        path: str,
+    ) -> list[Reviewer]:
+        """Load reviewers from the repository availability file."""
+        raw_b64 = await self._gh.get_file_content(
+            owner,
+            repo,
+            path,
+            installation_id,
+        )
+
+        if raw_b64 is None:
+            log.warning("Reviewer availability file %s not found", path)
+            return []
+
+        try:
+            content = base64.b64decode(raw_b64).decode("utf-8")
+            data = yaml.safe_load(content) or {}
+            reviewers = ReviewersFile.model_validate(data)
+            return reviewers.reviewers
+        except (ValidationError, yaml.YAMLError) as exc:
+            log.warning(
+                "Failed to load reviewer availability file %s: %s",
+                path,
+                exc,
+            )
+            return []
+
+    @staticmethod
+    def _select_reviewers(
+        reviewers: list[Reviewer],
+        *,
+        pr_number: int,
+        reviewers_count: int,
+        strategy: ReviewerAssignmentStrategy,
+    ) -> list[str]:
+        """Select reviewers using the configured strategy."""
+        if not reviewers:
+            return []
+
+        reviewers_count = min(reviewers_count, len(reviewers))
+
+        if strategy == "random":
+            return [
+                reviewer.login
+                for reviewer in random.sample(reviewers, reviewers_count)
+            ]
+
+        start = pr_number % len(reviewers)
+
+        ordered = reviewers[start:] + reviewers[:start]
+
+        return [
+            reviewer.login
+            for reviewer in ordered[:reviewers_count]
+        ]
+
+    async def handle_pr_opened(self, ctx: dict, payload: dict) -> None:
+        cfg = ctx["config"].workflows.reviewer_assignment
+        if not cfg.enabled:
+            return
+
+        pr = payload.get("pull_request", {})
+        if not pr:
+            return
+
+        owner = ctx["owner"]
+        repo = ctx["repo"]
+        installation_id = ctx["installation_id"]
+        db = ctx["db"]
+
+        pr_number = pr["number"]
+        author = pr["user"]["login"]
+
+        reviewers = await self._load_reviewers(
+            owner,
+            repo,
+            installation_id,
+            cfg.availability_file,
+        )
+
+        if not reviewers:
+            log.info("No reviewers available for assignment")
+            return
+
+        available_reviewers = [
+            reviewer
+            for reviewer in reviewers
+            if reviewer.available
+        ]
+
+        if cfg.exclude_pr_author:
+            available_reviewers = [
+                reviewer
+                for reviewer in available_reviewers
+                if reviewer.login != author
+            ]
+
+        if (
+            not available_reviewers
+            and cfg.fallback_to_all_if_none_available
+        ):
+            available_reviewers = reviewers
+
+            if cfg.exclude_pr_author:
+                available_reviewers = [
+                    reviewer
+                    for reviewer in available_reviewers
+                    if reviewer.login != author
+                ]
+
+        if not available_reviewers:
+            log.info(
+                "No eligible reviewers found for PR #%s",
+                pr_number,
+            )
+            return
+
+        selected_reviewers = self._select_reviewers(
+            available_reviewers,
+            pr_number=pr_number,
+            reviewers_count=cfg.reviewers_count,
+            strategy=cfg.strategy,
+        )
+
+        if not selected_reviewers:
+            return
+
+        await self._gh.request_reviewers(
+            owner,
+            repo,
+            pr_number,
+            selected_reviewers,
+            installation_id,
+        )
+
+        if cfg.notify_comment == "mention":
+            mentions = " ".join(
+                f"@{reviewer}"
+                for reviewer in selected_reviewers
+            )
+
+            await self._gh.post_comment(
+                owner,
+                repo,
+                pr_number,
+                f"{mentions} please review this PR 🙏",
+                installation_id,
+            )
+
+        await audit.record(
+            db,
+            action="pr.reviewer_assigned",
+            owner=owner,
+            repo=repo,
+            target_number=pr_number,
+            target_login=author,
+            reason="Automatically assigned reviewers",
+            metadata={
+                "reviewers": selected_reviewers,
+                "reviewers_count": len(selected_reviewers),
+                "strategy": cfg.strategy,
+            },
+        )
+
+        await db.commit()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ async def db():
 def mock_gh():
     gh = AsyncMock()
     gh.post_comment = AsyncMock()
+    gh.request_reviewers = AsyncMock()
     gh.add_label = AsyncMock()
     gh.add_assignees = AsyncMock()
     gh.remove_assignees = AsyncMock()
@@ -42,6 +43,7 @@ def mock_gh():
     })
     gh.get_collaborator_permission = AsyncMock(return_value="write")
     gh.list_team_members = AsyncMock(return_value=[{"login": "mentor1"}])
+    gh.get_file_content = AsyncMock(return_value=None)
     gh.get = AsyncMock(return_value=[])
     return gh
 

--- a/tests/unit/test_reviewer_assignment.py
+++ b/tests/unit/test_reviewer_assignment.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import base64
+from unittest.mock import AsyncMock
+
+import pytest
+import yaml
+
+from app.workflows.reviewerassignment import ReviewerAssignmentWorkflow
+
+
+def make_pr(number=1, author="alice"):
+    return {
+        "number": number,
+        "title": "feat: add feature",
+        "body": "",
+        "user": {"login": author},
+        "head": {"sha": "abc123"},
+        "draft": False,
+    }
+
+
+def make_payload(pr=None):
+    return {"pull_request": pr or make_pr()}
+
+
+def reviewers_file(reviewers):
+    return base64.b64encode(
+        yaml.safe_dump({"reviewers": reviewers}).encode()
+    ).decode()
+
+
+@pytest.mark.asyncio
+async def test_skips_when_disabled(mock_gh, ctx):
+    ctx["config"].workflows.reviewer_assignment.enabled = False
+
+    wf = ReviewerAssignmentWorkflow(mock_gh)
+    await wf.handle_pr_opened(ctx, make_payload())
+
+    mock_gh.request_reviewers.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_assigns_available_reviewer(mock_gh, ctx):
+    ctx["config"].workflows.reviewer_assignment.enabled = True
+
+    mock_gh.get_file_content = AsyncMock(
+        return_value=reviewers_file(
+            [
+                {"login": "bob", "available": True},
+            ]
+        )
+    )
+
+    wf = ReviewerAssignmentWorkflow(mock_gh)
+
+    await wf.handle_pr_opened(ctx, make_payload())
+
+    mock_gh.request_reviewers.assert_awaited_once()
+
+    reviewers = mock_gh.request_reviewers.call_args.args[3]
+
+    assert reviewers == ["bob"]
+
+
+@pytest.mark.asyncio
+async def test_skips_unavailable_reviewers(mock_gh, ctx):
+    ctx["config"].workflows.reviewer_assignment.enabled = True
+
+    mock_gh.get_file_content = AsyncMock(
+        return_value=reviewers_file(
+            [
+                {"login": "bob", "available": False},
+                {"login": "charlie", "available": True},
+            ]
+        )
+    )
+
+    wf = ReviewerAssignmentWorkflow(mock_gh)
+
+    await wf.handle_pr_opened(ctx, make_payload())
+
+    reviewers = mock_gh.request_reviewers.call_args.args[3]
+
+    assert reviewers == ["charlie"]
+
+
+@pytest.mark.asyncio
+async def test_excludes_pr_author(mock_gh, ctx):
+    ctx["config"].workflows.reviewer_assignment.enabled = True
+
+    mock_gh.get_file_content = AsyncMock(
+        return_value=reviewers_file(
+            [
+                {"login": "alice", "available": True},
+                {"login": "bob", "available": True},
+            ]
+        )
+    )
+
+    wf = ReviewerAssignmentWorkflow(mock_gh)
+
+    await wf.handle_pr_opened(ctx, make_payload())
+
+    reviewers = mock_gh.request_reviewers.call_args.args[3]
+
+    assert reviewers == ["bob"]


### PR DESCRIPTION
## Summary

This PR introduces a configurable reviewer assignment workflow that automatically requests reviewers when a new pull request is opened.

### What's Included

- Added a new `ReviewerAssignmentWorkflow`
- Added configurable reviewer assignment settings to the configuration schema
- Added support for reviewer availability through `.github/reviewers.yml`
- Added reviewer selection strategies:
  - `round-robin`
  - `random`
- Added support for:
  - excluding the PR author
  - configurable reviewer count
  - fallback to all reviewers when no available reviewers exist
  - optional reviewer mention comment
- Added GitHub client helper for requesting reviewers
- Integrated reviewer assignment into the pull request webhook flow
- Added audit logging for reviewer assignments
- Added unit tests covering reviewer assignment behavior

### Additional Cleanup

While working on this feature, I also fixed an existing Ruff lint warning in `.github/scripts/check_audit_severity.py` by replacing:

```python
value.startswith("CVSS:3") or value.startswith("AV:")
```

with the Ruff-recommended form:

```python
value.startswith(("CVSS:3", "AV:"))
```

This change is unrelated to the reviewer assignment feature but allows the project to pass `ruff check .` cleanly.

### Testing

Executed successfully:

```bash
ruff check .
pytest
python -m py_compile app/workflows/reviewerassignment.py
python -m py_compile app/github/webhooks.py
python -m py_compile tests/unit/test_reviewer_assignment.py
```

Results:

- ✅ Ruff checks passed
- ✅ All tests passed (`83 passed`)
- ✅ New reviewer assignment tests passed (`4 passed`)

### Example Configuration

```yaml
workflows:
  reviewer_assignment:
    enabled: true
    availability_file: ".github/reviewers.yml"
    reviewers_count: 1
    strategy: round-robin
    exclude_pr_author: true
    fallback_to_all_if_none_available: true
    notify_comment: off
```

Reviewer availability is configured in:

```yaml
reviewers:
  - login: user1
    available: true

  - login: user2
    available: true
```

Closes #11 