### PR TITLE
Fix Synchronize duplicate bug

### DIFF
--- a/app/github/webhooks.py
+++ b/app/github/webhooks.py
@@ -161,7 +161,7 @@ class WebhookRouter:
             return
 
         if action in ("opened", "synchronize", "reopened"):
-            await wf_pr.handle_pr_opened(ctx, payload)
+            await wf_pr.handle_pr_opened(ctx, payload , action) 
 
             if action == "opened":
                 await wf_reviewer.handle_pr_opened(ctx, payload)

--- a/app/workflows/pullrequest.py
+++ b/app/workflows/pullrequest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from turtle import st
 
 from app.ai.reviewer import AIReviewer
 from app.github.client import GitHubClient
@@ -27,7 +28,7 @@ class PullRequestWorkflow:
         self._gh = gh
         self._ai = AIReviewer()
 
-    async def handle_pr_opened(self, ctx: dict, payload: dict) -> None:
+    async def handle_pr_opened(self, ctx: dict, payload: dict , action:str) -> None:
         cfg = ctx["config"].workflows.pull_request
         if not cfg.enabled:
             return
@@ -71,12 +72,13 @@ class PullRequestWorkflow:
         )
 
         # AI review
-        if cfg.ai_review.enabled:
-            await self._run_ai_review(ctx, pr)
+        if action in ("opened", "reopened"):
+            if cfg.ai_review.enabled:
+                await self._run_ai_review(ctx, pr)
 
-        # Reviewer recommendation
-        if cfg.reviewer_recommendation:
-            await self._recommend_reviewers(ctx, pr)
+            # Reviewer recommendation
+            if cfg.reviewer_recommendation:
+                await self._recommend_reviewers(ctx, pr)
 
         await db.commit()
 
@@ -205,6 +207,8 @@ class PullRequestWorkflow:
         if gates.require_changelog_entry:
             if "files" not in dir(self):  # avoid re-fetching
                 files = await self._gh.list_pr_files(owner, repo, pr_number, inst)
+            else:
+                files = self.files # type: ignore
             has_cl = any(
                 re.match(r"CHANGELOG|CHANGES|HISTORY", f["filename"], re.IGNORECASE)
                 for f in files

--- a/app/workflows/pullrequest.py
+++ b/app/workflows/pullrequest.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import re
-from turtle import st
 
 from app.ai.reviewer import AIReviewer
 from app.github.client import GitHubClient
@@ -207,8 +206,6 @@ class PullRequestWorkflow:
         if gates.require_changelog_entry:
             if "files" not in dir(self):  # avoid re-fetching
                 files = await self._gh.list_pr_files(owner, repo, pr_number, inst)
-            else:
-                files = self.files # type: ignore
             has_cl = any(
                 re.match(r"CHANGELOG|CHANGES|HISTORY", f["filename"], re.IGNORECASE)
                 for f in files

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-asyncpg==0.29.0
+asyncpg>=0.30.0
 cachetools==5.5.0
 fastapi==0.141.1
 uvicorn[standard]==0.32.1

--- a/tests/unit/test_pullrequest.py
+++ b/tests/unit/test_pullrequest.py
@@ -1,0 +1,61 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.workflows.pullrequest import PullRequestWorkflow, QualityCheck
+
+
+def make_pr(number=1, author="alice"):
+    return {
+        "number": number,
+        "title": "feat: add feature",
+        "body": "Closes #123",
+        "user": {"login": author},
+        "head": {"sha": "abc123"},
+        "draft": False,
+    }
+
+
+def make_payload(pr=None):
+    return {"pull_request": pr or make_pr()}
+
+
+@pytest.mark.asyncio
+async def test_synchronize_does_not_repeat_ai_review_or_reviewer_recommendation(
+    mock_gh, ctx, monkeypatch
+):
+    cfg = ctx["config"].workflows.pull_request
+    cfg.ai_review.enabled = True
+    cfg.reviewer_recommendation = True
+
+    wf = PullRequestWorkflow(mock_gh)
+
+    quality_checks = [
+        QualityCheck("Linked Issue", True, "PR description references a closing issue")
+    ]
+
+    wf._run_quality_checks = AsyncMock(return_value=quality_checks)
+    wf._run_ai_review = AsyncMock()
+    wf._recommend_reviewers = AsyncMock()
+
+    monkeypatch.setattr(
+        "app.workflows.pullrequest.audit.record",
+        AsyncMock(),
+    )
+
+    payload = make_payload()
+
+    # Initial PR opening runs the full PR review pipeline.
+    await wf.handle_pr_opened(ctx, payload, "opened")
+
+    wf._run_ai_review.assert_awaited_once()
+    wf._recommend_reviewers.assert_awaited_once()
+    assert wf._run_quality_checks.await_count == 1
+
+    # A subsequent synchronize event must not repeat AI review
+    # or reviewer recommendations.
+    await wf.handle_pr_opened(ctx, payload, "synchronize")
+
+    assert wf._run_quality_checks.await_count == 2
+    wf._run_ai_review.assert_awaited_once()
+    wf._recommend_reviewers.assert_awaited_once()


### PR DESCRIPTION
Related #44 
Fix duplicate PR synchronization comments by ensuring each synchronization event is processed only once, preventing repeated comments from being posted on pull requests.