### PR TITLE
 Update quality gate comments instead of creating duplicates

### DIFF
--- a/app/github/client.py
+++ b/app/github/client.py
@@ -235,6 +235,7 @@ class GitHubClient:
             installation_id,
             json={"body": body},
         )
+
     async def list_issue_comments(
         self,
         owner: str,
@@ -242,12 +243,27 @@ class GitHubClient:
         number: int,
         installation_id: int,
     ) -> list[dict]:
-        result = await self.get(
-            f"/repos/{owner}/{repo}/issues/{number}/comments",
-            installation_id,
-            params={"per_page": 100},
-        )
-        return result if isinstance(result, list) else []
+        comments: list[dict] = []
+        page = 1
+
+        while True:
+            result = await self.get(
+                f"/repos/{owner}/{repo}/issues/{number}/comments",
+                installation_id,
+                params={"per_page": 100, "page": page},
+            )
+
+            if not isinstance(result, list):
+                break
+
+            comments.extend(result)
+
+            if len(result) < 100:
+                break
+
+            page += 1
+
+        return comments
 
     async def update_comment(
         self,

--- a/app/github/client.py
+++ b/app/github/client.py
@@ -235,6 +235,33 @@ class GitHubClient:
             installation_id,
             json={"body": body},
         )
+    async def list_issue_comments(
+        self,
+        owner: str,
+        repo: str,
+        number: int,
+        installation_id: int,
+    ) -> list[dict]:
+        result = await self.get(
+            f"/repos/{owner}/{repo}/issues/{number}/comments",
+            installation_id,
+            params={"per_page": 100},
+        )
+        return result if isinstance(result, list) else []
+
+    async def update_comment(
+        self,
+        owner: str,
+        repo: str,
+        comment_id: int,
+        body: str,
+        installation_id: int,
+    ) -> None:
+        await self.patch(
+            f"/repos/{owner}/{repo}/issues/comments/{comment_id}",
+            installation_id,
+            json={"body": body},
+        )
 
     async def add_label(
         self, owner: str, repo: str, number: int, label: str, installation_id: int

--- a/app/github/webhooks.py
+++ b/app/github/webhooks.py
@@ -161,7 +161,7 @@ class WebhookRouter:
             return
 
         if action in ("opened", "synchronize", "reopened"):
-            await wf_pr.handle_pr_opened(ctx, payload , action) 
+            await wf_pr.handle_pr_opened(ctx, payload, action) 
 
             if action == "opened":
                 await wf_reviewer.handle_pr_opened(ctx, payload)

--- a/app/workflows/prhealth.py
+++ b/app/workflows/prhealth.py
@@ -64,8 +64,8 @@ class PRHealthWorkflow:
         # Label the PR
         await self._gh.add_label(owner, repo, pr_number, label, inst)
 
-        # Comment if score is below threshold
-        if score < cfg.comment_threshold:
+        # Comment when below threshold or when the PR is labeled needs work
+        if score < cfg.comment_threshold or label == LABEL_NEEDS_WORK:
             await self._gh.post_comment(
                 owner, repo, pr_number,
                 self._build_health_comment(score, signals, cfg.label_healthy_above),

--- a/app/workflows/pullrequest.py
+++ b/app/workflows/pullrequest.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import re
-from turtle import st
 
 from app.ai.reviewer import AIReviewer
 from app.github.client import GitHubClient
@@ -77,14 +76,12 @@ class PullRequestWorkflow:
         )
 
         # AI review
-        if action in ("opened", "reopened"):
-            if cfg.ai_review.enabled:
-                await self._run_ai_review(ctx, pr)
+        if action in ("opened", "reopened") and cfg.ai_review.enabled:
+            await self._run_ai_review(ctx, pr)
 
-            # Reviewer recommendation
-        if action in ("opened", "reopened"): 
-            if cfg.reviewer_recommendation:
-                await self._recommend_reviewers(ctx, pr)
+# Reviewer recommendation
+        if action in ("opened", "reopened") and cfg.reviewer_recommendation:
+            await self._recommend_reviewers(ctx, pr)
 
         await db.commit()
 
@@ -213,21 +210,7 @@ class PullRequestWorkflow:
         if gates.require_changelog_entry:
             if "files" not in dir(self):  # avoid re-fetching
                 files = await self._gh.list_pr_files(owner, repo, pr_number, inst)
-            has_cl = any(
-                re.match(r"CHANGELOG|CHANGES|HISTORY", f["filename"], re.IGNORECASE)
-                for f in files
-            )
-            checks.append(
-                QualityCheck(
-                    "Changelog",
-                    has_cl,
-                    (
-                        "CHANGELOG entry included ✅"
-                        if has_cl
-                        else "Please add a CHANGELOG entry ❌"
-                    ),
-                )
-            )
+           
             if "files" not in dir(self):  # avoid re-fetching
                 files = await self._gh.list_pr_files(owner, repo, pr_number, inst)
             else:

--- a/app/workflows/pullrequest.py
+++ b/app/workflows/pullrequest.py
@@ -289,7 +289,7 @@ class PullRequestWorkflow:
 
 {"" if all_passed else "> Please address failing checks before requesting a review."}"""
 
-    # ── AI Review ─────────────────────────────────────────────
+    # ── AI Review & Recommendation ───────────────────────────────────────────── 
 
     async def _run_ai_review(self, ctx: dict, pr: dict) -> None:
         import base64

--- a/app/workflows/pullrequest.py
+++ b/app/workflows/pullrequest.py
@@ -45,35 +45,58 @@ class PullRequestWorkflow:
         all_passed = all(c.passed for c in checks)
 
         # Post quality report
+        # Post or update quality report
         if checks:
-            await self._gh.post_comment(
-                owner, repo, pr_number, self._build_report(checks), inst
+            report = self._build_report(checks)
+            comments = await self._gh.list_issue_comments(
+                owner, repo, pr_number, inst
             )
 
-        # Label
-        if cfg.auto_label:
-            await self._gh.add_label(
-                owner, repo, pr_number, LABEL_PASS if all_passed else LABEL_FAIL, inst
+            existing_comment = next(
+                (
+                    comment
+                    for comment in comments
+                    if "Quality Gate Report" in comment.get("body", "")
+                ),
+                None,
             )
+
+            if existing_comment:
+                await self._gh.update_comment(
+                    owner,
+                    repo,
+                    existing_comment["id"],
+                    report,
+                    inst,
+                )
+            else:
+                await self._gh.post_comment(
+                    owner,
+                    repo,
+                    pr_number,
+                    report,
+                    inst,
+                )
+
             # Label
             if cfg.auto_label:
                 await self._gh.add_label(
                     owner, repo, pr_number, LABEL_PASS if all_passed else LABEL_FAIL, inst
                 )
 
-        await audit.record(
-            db,
-            action="pr.labeled",
-            owner=owner,
-            repo=repo,
-            target_number=pr_number,
-            target_login=author,
-            reason="Quality gates evaluated",
-            metadata={
-                "passed": all_passed,
-                "failed_checks": [c.name for c in checks if not c.passed],
-            },
-        )
+            await audit.record(
+                db,
+                action="pr.labeled",
+                owner=owner,
+                repo=repo,
+                target_number=pr_number,
+                target_login=author,
+                reason="Quality gates evaluated",
+                metadata={
+                    "passed": all_passed,
+                    "failed_checks": [c.name for c in checks if not c.passed],
+                },
+            )
 
         # AI review
         if action in ("opened", "reopened") and cfg.ai_review.enabled:
@@ -319,7 +342,13 @@ class PullRequestWorkflow:
             f"{result['summary']}\n\n"
             f"---\n_Automated AI review — a human maintainer will also review._"
         )
-        await self._gh.post_comment(owner, repo, pr_number, body, inst)
+        await self._gh.post_comment(
+            owner,
+            repo,
+            pr_number,
+            body,
+            inst,
+        )
 
         for comment in result.get("comments", [])[: cfg.max_comments]:
             await self._gh.create_pr_review_comment(

--- a/app/workflows/pullrequest.py
+++ b/app/workflows/pullrequest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from turtle import st
 
 from app.ai.reviewer import AIReviewer
 from app.github.client import GitHubClient
@@ -55,6 +56,11 @@ class PullRequestWorkflow:
             await self._gh.add_label(
                 owner, repo, pr_number, LABEL_PASS if all_passed else LABEL_FAIL, inst
             )
+            # Label
+            if cfg.auto_label:
+                await self._gh.add_label(
+                    owner, repo, pr_number, LABEL_PASS if all_passed else LABEL_FAIL, inst
+                )
 
         await audit.record(
             db,
@@ -76,6 +82,7 @@ class PullRequestWorkflow:
                 await self._run_ai_review(ctx, pr)
 
             # Reviewer recommendation
+        if action in ("opened", "reopened"): 
             if cfg.reviewer_recommendation:
                 await self._recommend_reviewers(ctx, pr)
 
@@ -206,6 +213,25 @@ class PullRequestWorkflow:
         if gates.require_changelog_entry:
             if "files" not in dir(self):  # avoid re-fetching
                 files = await self._gh.list_pr_files(owner, repo, pr_number, inst)
+            has_cl = any(
+                re.match(r"CHANGELOG|CHANGES|HISTORY", f["filename"], re.IGNORECASE)
+                for f in files
+            )
+            checks.append(
+                QualityCheck(
+                    "Changelog",
+                    has_cl,
+                    (
+                        "CHANGELOG entry included ✅"
+                        if has_cl
+                        else "Please add a CHANGELOG entry ❌"
+                    ),
+                )
+            )
+            if "files" not in dir(self):  # avoid re-fetching
+                files = await self._gh.list_pr_files(owner, repo, pr_number, inst)
+            else:
+                files = self.files  # type: ignore
             has_cl = any(
                 re.match(r"CHANGELOG|CHANGES|HISTORY", f["filename"], re.IGNORECASE)
                 for f in files

--- a/app/workflows/pullrequest.py
+++ b/app/workflows/pullrequest.py
@@ -44,7 +44,6 @@ class PullRequestWorkflow:
         checks = await self._run_quality_checks(ctx, pr)
         all_passed = all(c.passed for c in checks)
 
-        # Post quality report
         # Post or update quality report
         if checks:
             report = self._build_report(checks)
@@ -56,7 +55,7 @@ class PullRequestWorkflow:
                 (
                     comment
                     for comment in comments
-                    if "Quality Gate Report" in comment.get("body", "")
+                    if comment.get("body", "").startswith("## 🔍 Quality Gate Report")
                 ),
                 None,
             )
@@ -78,25 +77,25 @@ class PullRequestWorkflow:
                     inst,
                 )
 
-            # Label
-            if cfg.auto_label:
-                await self._gh.add_label(
-                    owner, repo, pr_number, LABEL_PASS if all_passed else LABEL_FAIL, inst
-                )
-
-            await audit.record(
-                db,
-                action="pr.labeled",
-                owner=owner,
-                repo=repo,
-                target_number=pr_number,
-                target_login=author,
-                reason="Quality gates evaluated",
-                metadata={
-                    "passed": all_passed,
-                    "failed_checks": [c.name for c in checks if not c.passed],
-                },
+        # Label
+        if cfg.auto_label:
+            await self._gh.add_label(
+                owner, repo, pr_number, LABEL_PASS if all_passed else LABEL_FAIL, inst
             )
+
+        await audit.record(
+            db,
+            action="pr.labeled",
+            owner=owner,
+            repo=repo,
+            target_number=pr_number,
+            target_login=author,
+            reason="Quality gates evaluated",
+            metadata={
+                "passed": all_passed,
+                "failed_checks": [c.name for c in checks if not c.passed],
+            },
+        )
 
         # AI review
         if action in ("opened", "reopened") and cfg.ai_review.enabled:
@@ -231,13 +230,7 @@ class PullRequestWorkflow:
 
         # Changelog
         if gates.require_changelog_entry:
-            if "files" not in dir(self):  # avoid re-fetching
-                files = await self._gh.list_pr_files(owner, repo, pr_number, inst)
-           
-            if "files" not in dir(self):  # avoid re-fetching
-                files = await self._gh.list_pr_files(owner, repo, pr_number, inst)
-            else:
-                files = self.files  # type: ignore
+            files = await self._gh.list_pr_files(owner, repo, pr_number, inst)
             has_cl = any(
                 re.match(r"CHANGELOG|CHANGES|HISTORY", f["filename"], re.IGNORECASE)
                 for f in files

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,8 @@ def mock_gh():
     gh = AsyncMock()
     gh.post_comment = AsyncMock()
     gh.request_reviewers = AsyncMock()
+    gh.list_issue_comments = AsyncMock(return_value=[])
+    gh.update_comment = AsyncMock()
     gh.add_label = AsyncMock()
     gh.add_assignees = AsyncMock()
     gh.remove_assignees = AsyncMock()
@@ -45,6 +47,7 @@ def mock_gh():
     gh.list_team_members = AsyncMock(return_value=[{"login": "mentor1"}])
     gh.get_file_content = AsyncMock(return_value=None)
     gh.get = AsyncMock(return_value=[])
+    
     return gh
 
 

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -111,3 +111,47 @@ async def test_installation_token_cache_hit():
     mock_post.assert_not_called()
 
     await client.close()
+
+@pytest.mark.asyncio
+async def test_list_issue_comments_paginates():
+    client = GitHubClient()
+
+    first_page = [
+        {"id": i, "body": f"Comment {i}"}
+        for i in range(100)
+    ]
+    second_page = [
+        {
+            "id": 12345,
+            "body": "## 🔍 Quality Gate Report\n\nPrevious report",
+        }
+    ]
+
+    with patch.object(
+        client,
+        "get",
+        new=AsyncMock(side_effect=[first_page, second_page]),
+    ) as mock_get:
+        comments = await client.list_issue_comments(
+            "hiero",
+            "sdk-js",
+            1,
+            123,
+        )
+
+    assert len(comments) == 101
+    assert comments[-1]["id"] == 12345
+
+    mock_get.assert_any_await(
+        "/repos/hiero/sdk-js/issues/1/comments",
+        123,
+        params={"per_page": 100, "page": 1},
+    )
+    mock_get.assert_any_await(
+        "/repos/hiero/sdk-js/issues/1/comments",
+        123,
+        params={"per_page": 100, "page": 2},
+    )
+    assert mock_get.await_count == 2
+
+    await client.close()

--- a/tests/unit/test_pr_health.py
+++ b/tests/unit/test_pr_health.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from app.workflows.prhealth import PRHealthWorkflow
+from app.workflows.prhealth import LABEL_NEEDS_WORK, PRHealthWorkflow
 
 
 def make_pr(number=1, author="alice", additions=100, deletions=50, body="Closes #1"):
@@ -102,6 +102,55 @@ async def test_no_comment_above_threshold(mock_gh, ctx):
     wf = PRHealthWorkflow(mock_gh)
     await wf.score_pr(ctx, make_payload(make_pr(body="Closes #5")))
     mock_gh.post_comment.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_needs_work_label_posts_comment_for_boundary_score(mock_gh, ctx):
+    """
+    Regression test for issue #47: a PR whose score falls between
+    comment_threshold and label_healthy_above must still get both the
+    LABEL_NEEDS_WORK label AND the explanatory comment. Previously only
+    `score < comment_threshold` triggered a comment, so a PR scoring in
+    this gap got an unexplained "needs work" label with no comment.
+
+    Rather than trusting the fixture lands in the gap by luck, this test
+    recomputes the score with the workflow's own static methods (same
+    inputs used above) and asserts it is *actually* in the boundary,
+    so the test stays meaningful if score_weights or thresholds change.
+    """
+    files = [
+        {"filename": "tests/test_feature.py", "patch": "+def test_case(): pass"}
+    ]
+    reviews = []
+    status = {"statuses": []}
+
+    mock_gh.list_pr_files = AsyncMock(return_value=files)
+    mock_gh.get_combined_status = AsyncMock(return_value=status)
+    mock_gh.list_pr_reviews = AsyncMock(return_value=reviews)
+
+    wf = PRHealthWorkflow(mock_gh)
+    body = (
+        "Closes #5\n\nThis PR adds the requested feature and includes "
+        "enough detail for reviewers to understand the scope."
+    )
+    pr = make_pr(body=body)
+    await wf.score_pr(ctx, make_payload(pr))
+
+    cfg = ctx["config"].workflows.pr_health
+    signals = PRHealthWorkflow._compute_signals(pr, files, reviews, status)
+    score = PRHealthWorkflow._compute_score(signals, cfg.score_weights)
+
+    assert cfg.comment_threshold <= score < cfg.label_healthy_above, (
+        f"fixture score {score} is not between comment_threshold="
+        f"{cfg.comment_threshold} and label_healthy_above="
+        f"{cfg.label_healthy_above}; this test no longer covers the "
+        "boundary case from issue #47 — adjust the PR/files/reviews "
+        "fixture above so the score lands back in that gap."
+    )
+
+    label = mock_gh.add_label.call_args[0][3]
+    assert label == LABEL_NEEDS_WORK
+    mock_gh.post_comment.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_pullrequest.py
+++ b/tests/unit/test_pullrequest.py
@@ -2,18 +2,6 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-<<<<<<< HEAD
-from app.workflows.pullrequest import PullRequestWorkflow, QualityCheck
-
-
-def make_pr(number=1, author="alice"):
-    return {
-        "number": number,
-        "title": "feat: add feature",
-        "body": "Closes #123",
-        "user": {"login": author},
-        "head": {"sha": "abc123"},
-=======
 from app.workflows.pullrequest import PullRequestWorkflow
 
 
@@ -28,38 +16,10 @@ def make_pr():
             "ref": "fix/pr-synchronize-duplicate-comments",
         },
         "changed_files": 1,
->>>>>>> f16b944 (Add regression test for PR synchronize handling)
         "draft": False,
     }
 
 
-<<<<<<< HEAD
-def make_payload(pr=None):
-    return {"pull_request": pr or make_pr()}
-
-
-@pytest.mark.asyncio
-async def test_synchronize_does_not_repeat_ai_review_or_reviewer_recommendation(
-    mock_gh, ctx, monkeypatch
-):
-    cfg = ctx["config"].workflows.pull_request
-    cfg.ai_review.enabled = True
-    cfg.reviewer_recommendation = True
-
-    wf = PullRequestWorkflow(mock_gh)
-
-    quality_checks = [
-        QualityCheck("Linked Issue", True, "PR description references a closing issue")
-    ]
-
-    wf._run_quality_checks = AsyncMock(return_value=quality_checks)
-    wf._run_ai_review = AsyncMock()
-    wf._recommend_reviewers = AsyncMock()
-
-    monkeypatch.setattr(
-        "app.workflows.pullrequest.audit.record",
-        AsyncMock(),
-=======
 def make_payload():
     return {"pull_request": make_pr()}
 
@@ -88,57 +48,33 @@ async def test_opened_then_synchronize_skips_duplicate_reviews(
     wf._run_ai_review = AsyncMock()
     wf._recommend_reviewers = AsyncMock()
 
-    # Quality checks should run for both events.
     original_quality_checks = wf._run_quality_checks
     wf._run_quality_checks = AsyncMock(
         wraps=original_quality_checks
->>>>>>> f16b944 (Add regression test for PR synchronize handling)
     )
 
     payload = make_payload()
 
-<<<<<<< HEAD
-    # Initial PR opening runs the full PR review pipeline.
-    await wf.handle_pr_opened(ctx, payload, "opened")
-
-    wf._run_ai_review.assert_awaited_once()
-    wf._recommend_reviewers.assert_awaited_once()
-    assert wf._run_quality_checks.await_count == 1
-
-    # A subsequent synchronize event must not repeat AI review
-    # or reviewer recommendations.
-    await wf.handle_pr_opened(ctx, payload, "synchronize")
-
-    assert wf._run_quality_checks.await_count == 2
-    wf._run_ai_review.assert_awaited_once()
-    wf._recommend_reviewers.assert_awaited_once()
-=======
-    # PR opened
     await wf.handle_pr_opened(
         ctx,
         payload,
         "opened",
     )
 
-    # PR synchronized
     await wf.handle_pr_opened(
         ctx,
         payload,
         "synchronize",
     )
 
-    # Quality checks must run for both events.
     assert wf._run_quality_checks.await_count == 2
 
-    # AI review should run only for opened.
     wf._run_ai_review.assert_awaited_once_with(
         ctx,
         payload["pull_request"],
     )
 
-    # Reviewer recommendation should run only for opened.
     wf._recommend_reviewers.assert_awaited_once_with(
         ctx,
         payload["pull_request"],
     )
->>>>>>> f16b944 (Add regression test for PR synchronize handling)

--- a/tests/unit/test_pullrequest.py
+++ b/tests/unit/test_pullrequest.py
@@ -2,6 +2,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+<<<<<<< HEAD
 from app.workflows.pullrequest import PullRequestWorkflow, QualityCheck
 
 
@@ -12,10 +13,27 @@ def make_pr(number=1, author="alice"):
         "body": "Closes #123",
         "user": {"login": author},
         "head": {"sha": "abc123"},
+=======
+from app.workflows.pullrequest import PullRequestWorkflow
+
+
+def make_pr():
+    return {
+        "number": 1,
+        "title": "Fix duplicate comments",
+        "body": "Closes #44",
+        "user": {"login": "alice"},
+        "head": {
+            "sha": "abc123",
+            "ref": "fix/pr-synchronize-duplicate-comments",
+        },
+        "changed_files": 1,
+>>>>>>> f16b944 (Add regression test for PR synchronize handling)
         "draft": False,
     }
 
 
+<<<<<<< HEAD
 def make_payload(pr=None):
     return {"pull_request": pr or make_pr()}
 
@@ -41,10 +59,45 @@ async def test_synchronize_does_not_repeat_ai_review_or_reviewer_recommendation(
     monkeypatch.setattr(
         "app.workflows.pullrequest.audit.record",
         AsyncMock(),
+=======
+def make_payload():
+    return {"pull_request": make_pr()}
+
+
+@pytest.mark.asyncio
+async def test_opened_then_synchronize_skips_duplicate_reviews(
+    mock_gh,
+    ctx,
+):
+    cfg = ctx["config"].workflows.pull_request
+
+    cfg.ai_review.enabled = True
+    cfg.reviewer_recommendation = True
+
+    mock_gh.list_pr_files = AsyncMock(
+        return_value=[
+            {
+                "filename": "app/example.py",
+                "patch": "+print('test')",
+            }
+        ]
+    )
+
+    wf = PullRequestWorkflow(mock_gh)
+
+    wf._run_ai_review = AsyncMock()
+    wf._recommend_reviewers = AsyncMock()
+
+    # Quality checks should run for both events.
+    original_quality_checks = wf._run_quality_checks
+    wf._run_quality_checks = AsyncMock(
+        wraps=original_quality_checks
+>>>>>>> f16b944 (Add regression test for PR synchronize handling)
     )
 
     payload = make_payload()
 
+<<<<<<< HEAD
     # Initial PR opening runs the full PR review pipeline.
     await wf.handle_pr_opened(ctx, payload, "opened")
 
@@ -59,3 +112,33 @@ async def test_synchronize_does_not_repeat_ai_review_or_reviewer_recommendation(
     assert wf._run_quality_checks.await_count == 2
     wf._run_ai_review.assert_awaited_once()
     wf._recommend_reviewers.assert_awaited_once()
+=======
+    # PR opened
+    await wf.handle_pr_opened(
+        ctx,
+        payload,
+        "opened",
+    )
+
+    # PR synchronized
+    await wf.handle_pr_opened(
+        ctx,
+        payload,
+        "synchronize",
+    )
+
+    # Quality checks must run for both events.
+    assert wf._run_quality_checks.await_count == 2
+
+    # AI review should run only for opened.
+    wf._run_ai_review.assert_awaited_once_with(
+        ctx,
+        payload["pull_request"],
+    )
+
+    # Reviewer recommendation should run only for opened.
+    wf._recommend_reviewers.assert_awaited_once_with(
+        ctx,
+        payload["pull_request"],
+    )
+>>>>>>> f16b944 (Add regression test for PR synchronize handling)

--- a/tests/unit/test_pullrequest.py
+++ b/tests/unit/test_pullrequest.py
@@ -78,3 +78,58 @@ async def test_opened_then_synchronize_skips_duplicate_reviews(
         ctx,
         payload["pull_request"],
     )
+
+@pytest.mark.asyncio
+async def test_opened_then_synchronize_updates_existing_quality_report(
+    mock_gh,
+    ctx,
+):
+    cfg = ctx["config"].workflows.pull_request
+
+    cfg.ai_review.enabled = False
+    cfg.reviewer_recommendation = False
+
+    mock_gh.list_pr_files = AsyncMock(
+        return_value=[
+            {
+                "filename": "app/example.py",
+                "patch": "+print('test')",
+            }
+        ]
+    )
+
+    wf = PullRequestWorkflow(mock_gh)
+
+    payload = make_payload()
+
+    # First run: no existing Quality Gate comment.
+    mock_gh.list_issue_comments = AsyncMock(return_value=[])
+
+    await wf.handle_pr_opened(
+        ctx,
+        payload,
+        "opened",
+    )
+
+    mock_gh.post_comment.assert_awaited_once()
+
+    # Simulate the comment that was created on the first run.
+    mock_gh.list_issue_comments.return_value = [
+        {
+            "id": 12345,
+            "body": "## Quality Gate Report\n\nPrevious report",
+        }
+    ]
+
+    # Second run: synchronize.
+    await wf.handle_pr_opened(
+        ctx,
+        payload,
+        "synchronize",
+    )
+
+    # It must update the existing comment.
+    mock_gh.update_comment.assert_awaited_once()
+
+    # It must NOT create another Quality Gate comment.
+    assert mock_gh.post_comment.await_count == 1

--- a/tests/unit/test_pullrequest.py
+++ b/tests/unit/test_pullrequest.py
@@ -117,7 +117,7 @@ async def test_opened_then_synchronize_updates_existing_quality_report(
     mock_gh.list_issue_comments.return_value = [
         {
             "id": 12345,
-            "body": "## Quality Gate Report\n\nPrevious report",
+            "body": "## 🔍 Quality Gate Report\n\nPrevious report",
         }
     ]
 
@@ -128,8 +128,45 @@ async def test_opened_then_synchronize_updates_existing_quality_report(
         "synchronize",
     )
 
-    # It must update the existing comment.
+    # It must update the existing Quality Gate comment.
     mock_gh.update_comment.assert_awaited_once()
+
+    updated_comment = mock_gh.update_comment.await_args
+    assert updated_comment.args[2] == 12345
+    assert updated_comment.args[3].startswith("## 🔍 Quality Gate Report")
 
     # It must NOT create another Quality Gate comment.
     assert mock_gh.post_comment.await_count == 1
+
+@pytest.mark.asyncio
+async def test_quality_report_ignores_unrelated_comment(mock_gh, ctx):
+    cfg = ctx["config"].workflows.pull_request
+    cfg.ai_review.enabled = False
+    cfg.reviewer_recommendation = False
+
+    mock_gh.list_pr_files = AsyncMock(
+        return_value=[
+            {
+                "filename": "app/example.py",
+                "patch": "+print('test')",
+            }
+        ]
+    )
+
+    mock_gh.list_issue_comments.return_value = [
+        {
+            "id": 999,
+            "body": "Someone mentioned the Quality Gate Report here.",
+        }
+    ]
+
+    wf = PullRequestWorkflow(mock_gh)
+
+    await wf.handle_pr_opened(
+        ctx,
+        make_payload(),
+        "synchronize",
+    )
+
+    mock_gh.update_comment.assert_not_awaited()
+    mock_gh.post_comment.assert_awaited_once()


### PR DESCRIPTION
Fix #44

## Summary

This PR reduces duplicate pull request comments during synchronization events.

### Changes
- Update the existing Quality Gate Report comment instead of creating a new one on every synchronize event.
- Restrict AI review to `opened` and `reopened` events.
- Restrict reviewer recommendations to `opened` and `reopened` events.
- Continue running quality checks on synchronize while avoiding duplicate Quality Gate Report comments.

