### PR TITLE
fix: paginate stale scan and pass installation context (#39, #46)

### DIFF
--- a/app/github/client.py
+++ b/app/github/client.py
@@ -16,6 +16,11 @@ log = get_logger("github.client")
 
 GITHUB_API = "https://api.github.com"
 
+# Safety valve for paginated endpoints: 100 items/page × 50 pages = 5000 items.
+# Large enough for any realistic repository, small enough that a runaway loop
+# can't burn an installation's whole rate-limit budget.
+MAX_PAGES = 50
+
 _PEM_MARKERS = [
     (
         "-----BEGIN RSA PRIVATE KEY-----",
@@ -192,6 +197,101 @@ class GitHubClient:
     async def delete(self, path: str, installation_id: int, **kwargs: Any) -> Any:
         return await self.request("DELETE", path, installation_id, **kwargs)
 
+    # Pagination
+
+    async def paginate(
+        self,
+        path: str,
+        installation_id: int,
+        *,
+        params: dict[str, Any] | None = None,
+        per_page: int = 100,
+        max_pages: int = MAX_PAGES,
+        extract: str | None = None,
+    ) -> list[dict]:
+        """
+        Walk a paginated GitHub collection endpoint and return every item.
+
+        GitHub caps `per_page` at 100, so any endpoint queried without following
+        pages silently truncates once a repository grows past that. Callers get
+        the full collection here, bounded by ``max_pages`` so a pathological repo
+        can't turn one scan into thousands of requests.
+
+        ``extract`` names the key holding the list for endpoints that wrap their
+        results in an object (e.g. ``/installation/repositories`` →
+        ``repositories``).
+        """
+        items: list[dict] = []
+        page = 1
+
+        while page <= max_pages:
+            result = await self.get(
+                path,
+                installation_id,
+                params={**(params or {}), "per_page": per_page, "page": page},
+            )
+
+            batch = result.get(extract, []) if extract else result
+            if not isinstance(batch, list):
+                log.warning(
+                    "Unexpected paginated payload for %s (page %d): %s",
+                    path,
+                    page,
+                    type(batch).__name__,
+                )
+                break
+
+            items.extend(batch)
+
+            # A short page means we've reached the end of the collection.
+            if len(batch) < per_page:
+                return items
+
+            page += 1
+
+        log.warning(
+            "Pagination for %s stopped at the %d-page cap — results are truncated",
+            path,
+            max_pages,
+        )
+        return items
+
+    async def _paginate_app(
+        self,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        per_page: int = 100,
+        max_pages: int = MAX_PAGES,
+    ) -> list[dict]:
+        """Same as :meth:`paginate` but authenticated as the app, not an installation."""
+        items: list[dict] = []
+        page = 1
+
+        while page <= max_pages:
+            resp = await self._http.get(
+                path,
+                headers=self._app_headers(),
+                params={**(params or {}), "per_page": per_page, "page": page},
+            )
+            resp.raise_for_status()
+            batch = resp.json()
+
+            if not isinstance(batch, list):
+                break
+
+            items.extend(batch)
+
+            if len(batch) < per_page:
+                return items
+
+            page += 1
+
+        log.warning(
+            "App-level pagination for %s stopped at the %d-page cap", path, max_pages
+        )
+        return items
+
     # High-level helpers
 
     async def get_file_content(
@@ -355,10 +455,11 @@ class GitHubClient:
     async def list_issues(
         self, owner: str, repo: str, installation_id: int, **params: Any
     ) -> list[dict]:
-        return await self.get(
+        """List issues across every page — repos with >100 open issues need this."""
+        return await self.paginate(
             f"/repos/{owner}/{repo}/issues",
             installation_id,
-            params={"per_page": 100, **params},
+            params=params,
         )
 
     async def list_pr_files(
@@ -424,17 +525,16 @@ class GitHubClient:
             return []
 
     async def list_installations(self) -> list[dict]:
-        resp = await self._http.get(
-            "/app/installations", headers=self._app_headers(), params={"per_page": 100}
-        )
-        resp.raise_for_status()
-        return resp.json()
+        """Every installation of this app, across all pages."""
+        return await self._paginate_app("/app/installations")
 
     async def list_installation_repos(self, installation_id: int) -> list[dict]:
-        data = await self.get(
-            "/installation/repositories", installation_id, params={"per_page": 100}
+        """Every repo an installation can see — the response wraps them in an object."""
+        return await self.paginate(
+            "/installation/repositories",
+            installation_id,
+            extract="repositories",
         )
-        return data.get("repositories", [])
 
     async def create_pr_review_comment(
         self,

--- a/app/scheduler/jobs.py
+++ b/app/scheduler/jobs.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
+
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 
@@ -14,6 +16,32 @@ from app.workflows.issuemanagement import IssueManagementWorkflow
 log = get_logger("scheduler")
 
 
+@dataclass
+class ScanSummary:
+    """Aggregate outcome of one full stale scan across every installation."""
+
+    installations: int = 0
+    repos_scanned: int = 0
+    repos_skipped: int = 0
+    repos_failed: int = 0
+    totals: dict[str, int] = field(
+        default_factory=lambda: {"stale_marked": 0, "closed": 0, "unassigned": 0}
+    )
+
+    def add(self, counts: dict[str, int]) -> None:
+        for key, value in counts.items():
+            self.totals[key] = self.totals.get(key, 0) + value
+
+    def as_dict(self) -> dict:
+        return {
+            "installations": self.installations,
+            "repos_scanned": self.repos_scanned,
+            "repos_skipped": self.repos_skipped,
+            "repos_failed": self.repos_failed,
+            **self.totals,
+        }
+
+
 class BotScheduler:
     def __init__(self, gh: GitHubClient, config_loader: ConfigLoader) -> None:
         self._gh = gh
@@ -21,13 +49,18 @@ class BotScheduler:
         self._scheduler = AsyncIOScheduler()
 
     def start(self) -> None:
-        # Stale scan — every day at 02:00 UTC
+        # Stale scan — every day at 02:00 UTC.
+        # coalesce + max_instances=1 keep a slow scan from stacking up behind
+        # itself if the process was paused or the previous run overran.
         self._scheduler.add_job(
-            self._run_stale_scan,
+            self.run_stale_scan,
             CronTrigger(hour=2, minute=0),
             id="stale_scan",
             name="Daily stale issue scan",
             replace_existing=True,
+            coalesce=True,
+            max_instances=1,
+            misfire_grace_time=3600,
         )
         # Config cache flush — every 6 hours
         self._scheduler.add_job(
@@ -36,6 +69,8 @@ class BotScheduler:
             id="config_cache_flush",
             name="Config cache flush",
             replace_existing=True,
+            coalesce=True,
+            max_instances=1,
         )
         self._scheduler.start()
         log.info("Scheduler started")
@@ -43,16 +78,30 @@ class BotScheduler:
     def shutdown(self) -> None:
         self._scheduler.shutdown(wait=False)
 
-    async def _run_stale_scan(self) -> None:
+    async def run_stale_scan(self) -> ScanSummary:
+        """
+        Scan every repo of every installation for stale issues.
+
+        Public so it can be triggered manually (and asserted on in tests) rather
+        than only via the cron trigger.
+        """
         log.info("Starting scheduled stale scan")
+        summary = ScanSummary()
+
         try:
             installations = await self._gh.list_installations()
         except Exception as exc:
             log.error("Failed to list installations: %s", exc)
-            return
+            return summary
+
+        summary.installations = len(installations)
 
         for inst in installations:
-            inst_id = inst["id"]
+            inst_id = inst.get("id")
+            if not inst_id:
+                log.warning("Installation entry without an id — skipping")
+                continue
+
             try:
                 repos = await self._gh.list_installation_repos(inst_id)
             except Exception as exc:
@@ -60,32 +109,49 @@ class BotScheduler:
                 continue
 
             for repo_data in repos:
-                full_name: str = repo_data.get("full_name", "")
-                if "/" not in full_name:
-                    continue
-                owner, repo = full_name.split("/", 1)
+                await self._scan_repo(inst_id, repo_data, summary)
 
-                try:
-                    config = await self._config_loader.load(owner, repo)
-                    if not config or not config.workflows.issue_management.enabled:
-                        continue
+        log.info("Stale scan complete: %s", summary.as_dict())
+        return summary
 
-                    async with AsyncSessionLocal() as db:
-                        ctx = {
-                            "owner": owner,
-                            "repo": repo,
-                            "installation_id": inst_id,
-                            "config": config,
-                            "db": db,
-                        }
-                        wf = IssueManagementWorkflow(self._gh)
-                        counts = await wf.run_stale_scan(ctx)
-                        log.info("Stale scan %s/%s: %s", owner, repo, counts)
+    async def _scan_repo(
+        self, inst_id: int, repo_data: dict, summary: ScanSummary
+    ) -> None:
+        full_name: str = repo_data.get("full_name", "")
+        if "/" not in full_name:
+            summary.repos_skipped += 1
+            return
 
-                except Exception as exc:
-                    log.error("Stale scan failed for %s/%s: %s", owner, repo, exc)
+        owner, repo = full_name.split("/", 1)
 
-        log.info("Stale scan complete")
+        try:
+            # The installation id is required: without it the loader falls back
+            # to app-level auth, which cannot read a private repo's config and
+            # 404s on it — so every scheduled scan silently found "no config"
+            # and did nothing.
+            config = await self._config_loader.load(owner, repo, inst_id)
+            if not config or not config.workflows.issue_management.enabled:
+                summary.repos_skipped += 1
+                return
+
+            async with AsyncSessionLocal() as db:
+                ctx = {
+                    "owner": owner,
+                    "repo": repo,
+                    "installation_id": inst_id,
+                    "config": config,
+                    "db": db,
+                }
+                wf = IssueManagementWorkflow(self._gh)
+                counts = await wf.run_stale_scan(ctx)
+
+            summary.repos_scanned += 1
+            summary.add(counts)
+            log.info("Stale scan %s/%s: %s", owner, repo, counts)
+
+        except Exception as exc:
+            summary.repos_failed += 1
+            log.error("Stale scan failed for %s/%s: %s", owner, repo, exc)
 
     async def _flush_config_cache(self) -> None:
         self._config_loader.clear()

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -155,3 +155,180 @@ async def test_list_issue_comments_paginates():
     assert mock_get.await_count == 2
 
     await client.close()
+
+
+# ── Pagination ────────────────────────────────────────────────
+
+
+def page(size, start=0):
+    return [{"number": start + i} for i in range(size)]
+
+
+@pytest.mark.asyncio
+async def test_paginate_stops_on_short_page():
+    client = GitHubClient()
+
+    with patch.object(
+        client, "get", new=AsyncMock(side_effect=[page(100), page(7, 100)])
+    ) as mock_get:
+        items = await client.paginate("/repos/hiero/sdk-js/issues", 1)
+
+    assert len(items) == 107
+    assert mock_get.await_count == 2
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_paginate_single_short_page_makes_one_request():
+    client = GitHubClient()
+
+    with patch.object(client, "get", new=AsyncMock(return_value=page(3))) as mock_get:
+        items = await client.paginate("/repos/hiero/sdk-js/issues", 1)
+
+    assert len(items) == 3
+    assert mock_get.await_count == 1
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_paginate_empty_first_page():
+    client = GitHubClient()
+
+    with patch.object(client, "get", new=AsyncMock(return_value=[])) as mock_get:
+        items = await client.paginate("/repos/hiero/sdk-js/issues", 1)
+
+    assert items == []
+    assert mock_get.await_count == 1
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_paginate_respects_max_pages_cap():
+    client = GitHubClient()
+
+    with patch.object(client, "get", new=AsyncMock(return_value=page(100))) as mock_get:
+        items = await client.paginate("/repos/hiero/sdk-js/issues", 1, max_pages=3)
+
+    assert len(items) == 300
+    assert mock_get.await_count == 3
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_paginate_preserves_caller_params():
+    client = GitHubClient()
+
+    with patch.object(client, "get", new=AsyncMock(return_value=page(2))) as mock_get:
+        await client.paginate(
+            "/repos/hiero/sdk-js/issues", 9, params={"state": "open"}
+        )
+
+    mock_get.assert_awaited_once_with(
+        "/repos/hiero/sdk-js/issues",
+        9,
+        params={"state": "open", "per_page": 100, "page": 1},
+    )
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_paginate_extracts_wrapped_collection():
+    client = GitHubClient()
+
+    responses = [
+        {"total_count": 101, "repositories": page(100)},
+        {"total_count": 101, "repositories": page(1, 100)},
+    ]
+
+    with patch.object(client, "get", new=AsyncMock(side_effect=responses)):
+        repos = await client.paginate(
+            "/installation/repositories", 5, extract="repositories"
+        )
+
+    assert len(repos) == 101
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_paginate_breaks_on_unexpected_payload():
+    client = GitHubClient()
+
+    with patch.object(client, "get", new=AsyncMock(return_value={"message": "nope"})):
+        items = await client.paginate("/repos/hiero/sdk-js/issues", 1)
+
+    assert items == []
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_list_issues_walks_every_page():
+    """Regression for #46 — repos with >100 open issues got partial stale scans."""
+    client = GitHubClient()
+
+    with patch.object(
+        client, "get", new=AsyncMock(side_effect=[page(100), page(100, 100), page(5, 200)])
+    ) as mock_get:
+        issues = await client.list_issues(
+            "hiero", "sdk-js", 42, state="open", sort="updated"
+        )
+
+    assert len(issues) == 205
+    assert mock_get.await_count == 3
+    mock_get.assert_any_await(
+        "/repos/hiero/sdk-js/issues",
+        42,
+        params={"state": "open", "sort": "updated", "per_page": 100, "page": 3},
+    )
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_list_installation_repos_unwraps_and_paginates():
+    client = GitHubClient()
+
+    responses = [
+        {"repositories": [{"full_name": f"hiero/repo-{i}"} for i in range(100)]},
+        {"repositories": [{"full_name": "hiero/last"}]},
+    ]
+
+    with patch.object(client, "get", new=AsyncMock(side_effect=responses)):
+        repos = await client.list_installation_repos(7)
+
+    assert len(repos) == 101
+    assert repos[-1]["full_name"] == "hiero/last"
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_list_installations_paginates_with_app_auth():
+    client = GitHubClient()
+
+    first = Mock()
+    first.raise_for_status = Mock()
+    first.json = Mock(return_value=[{"id": i} for i in range(100)])
+
+    second = Mock()
+    second.raise_for_status = Mock()
+    second.json = Mock(return_value=[{"id": 100}])
+
+    with (
+        patch.object(client, "_make_jwt", return_value="fake_jwt"),
+        patch.object(
+            client._http, "get", new=AsyncMock(side_effect=[first, second])
+        ) as mock_get,
+    ):
+        installations = await client.list_installations()
+
+    assert len(installations) == 101
+    assert mock_get.await_count == 2
+
+    await client.close()

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -1,0 +1,167 @@
+# tests/unit/test_scheduler.py — scheduled stale scan
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.scheduler.jobs import BotScheduler, ScanSummary
+
+
+def make_loader(config=None, side_effect=None):
+    loader = MagicMock()
+    if side_effect is not None:
+        loader.load = AsyncMock(side_effect=side_effect)
+    else:
+        loader.load = AsyncMock(return_value=config)
+    loader.clear = MagicMock()
+    return loader
+
+
+@pytest.fixture
+def gh_with_one_repo():
+    gh = AsyncMock()
+    gh.list_installations = AsyncMock(return_value=[{"id": 42}])
+    gh.list_installation_repos = AsyncMock(
+        return_value=[{"full_name": "hiero/sdk-js"}]
+    )
+    gh.list_issues = AsyncMock(return_value=[])
+    return gh
+
+
+@pytest.mark.asyncio
+async def test_config_is_loaded_with_installation_id(gh_with_one_repo, base_config):
+    """Regression for #39 — the scan authenticated as the app and always 404'd."""
+    loader = make_loader(base_config)
+    scheduler = BotScheduler(gh_with_one_repo, loader)
+
+    await scheduler.run_stale_scan()
+
+    loader.load.assert_awaited_once_with("hiero", "sdk-js", 42)
+
+
+@pytest.mark.asyncio
+async def test_scan_reports_scanned_repos(gh_with_one_repo, base_config):
+    scheduler = BotScheduler(gh_with_one_repo, make_loader(base_config))
+
+    summary = await scheduler.run_stale_scan()
+
+    assert summary.installations == 1
+    assert summary.repos_scanned == 1
+    assert summary.repos_failed == 0
+
+
+@pytest.mark.asyncio
+async def test_repo_without_config_is_skipped(gh_with_one_repo):
+    scheduler = BotScheduler(gh_with_one_repo, make_loader(None))
+
+    summary = await scheduler.run_stale_scan()
+
+    assert summary.repos_skipped == 1
+    assert summary.repos_scanned == 0
+
+
+@pytest.mark.asyncio
+async def test_repo_with_issue_management_disabled_is_skipped(
+    gh_with_one_repo, base_config
+):
+    base_config.workflows.issue_management.enabled = False
+    scheduler = BotScheduler(gh_with_one_repo, make_loader(base_config))
+
+    summary = await scheduler.run_stale_scan()
+
+    assert summary.repos_skipped == 1
+
+
+@pytest.mark.asyncio
+async def test_one_failing_repo_does_not_abort_the_scan(base_config):
+    gh = AsyncMock()
+    gh.list_installations = AsyncMock(return_value=[{"id": 42}])
+    gh.list_installation_repos = AsyncMock(
+        return_value=[{"full_name": "hiero/broken"}, {"full_name": "hiero/sdk-js"}]
+    )
+    gh.list_issues = AsyncMock(return_value=[])
+
+    loader = make_loader(side_effect=[RuntimeError("boom"), base_config])
+    scheduler = BotScheduler(gh, loader)
+
+    summary = await scheduler.run_stale_scan()
+
+    assert summary.repos_failed == 1
+    assert summary.repos_scanned == 1
+
+
+@pytest.mark.asyncio
+async def test_malformed_repo_entry_is_skipped(base_config):
+    gh = AsyncMock()
+    gh.list_installations = AsyncMock(return_value=[{"id": 42}])
+    gh.list_installation_repos = AsyncMock(return_value=[{"name": "no-full-name"}])
+
+    loader = make_loader(base_config)
+    scheduler = BotScheduler(gh, loader)
+
+    summary = await scheduler.run_stale_scan()
+
+    assert summary.repos_skipped == 1
+    loader.load.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_installation_listing_failure_returns_empty_summary():
+    gh = AsyncMock()
+    gh.list_installations = AsyncMock(side_effect=RuntimeError("api down"))
+
+    scheduler = BotScheduler(gh, make_loader(None))
+    summary = await scheduler.run_stale_scan()
+
+    assert summary.installations == 0
+    assert summary.repos_scanned == 0
+
+
+@pytest.mark.asyncio
+async def test_repo_listing_failure_skips_that_installation(base_config):
+    gh = AsyncMock()
+    gh.list_installations = AsyncMock(return_value=[{"id": 1}, {"id": 2}])
+    gh.list_installation_repos = AsyncMock(
+        side_effect=[RuntimeError("no access"), [{"full_name": "hiero/sdk-js"}]]
+    )
+    gh.list_issues = AsyncMock(return_value=[])
+
+    scheduler = BotScheduler(gh, make_loader(base_config))
+    summary = await scheduler.run_stale_scan()
+
+    assert summary.installations == 2
+    assert summary.repos_scanned == 1
+
+
+@pytest.mark.asyncio
+async def test_installation_without_id_is_ignored(base_config):
+    gh = AsyncMock()
+    gh.list_installations = AsyncMock(return_value=[{"account": "orphan"}])
+    gh.list_installation_repos = AsyncMock(return_value=[])
+
+    scheduler = BotScheduler(gh, make_loader(base_config))
+    summary = await scheduler.run_stale_scan()
+
+    gh.list_installation_repos.assert_not_awaited()
+    assert summary.repos_scanned == 0
+
+
+def test_summary_accumulates_counts():
+    summary = ScanSummary()
+    summary.add({"stale_marked": 2, "closed": 1, "unassigned": 0})
+    summary.add({"stale_marked": 3, "closed": 0, "unassigned": 4})
+
+    assert summary.as_dict()["stale_marked"] == 5
+    assert summary.as_dict()["closed"] == 1
+    assert summary.as_dict()["unassigned"] == 4
+
+
+def test_flush_config_cache_clears_loader():
+    loader = make_loader(None)
+    scheduler = BotScheduler(AsyncMock(), loader)
+
+    import asyncio
+
+    asyncio.run(scheduler._flush_config_cache())
+
+    loader.clear.assert_called_once()


### PR DESCRIPTION
Closes #39 
Closes #46 
fix: paginate stale scan and pass installation context (#39, #46)

Two bugs made the scheduled stale scan a no-op or a partial scan on any
repository that had grown past a single page of results.

#39 — `_run_stale_scan` called `config_loader.load(owner, repo)` without an
installation id. The loader then fell back to app-level auth, which cannot
read repository contents, so every scheduled scan resolved to "no config"
and quietly did nothing. The scan now threads `inst_id` through to the
loader.

#46 — `list_issues` requested `per_page=100` and never followed the `page`
cursor, so repos with more than 100 open issues only ever had their first
page considered. Adds a general `GitHubClient.paginate()` helper (bounded by
a 50-page cap so a pathological repo can't exhaust the rate limit) and uses
it for issues, installations, and installation repositories.

Also hardens the job itself: per-repo failures no longer abort the whole
scan, malformed repo entries are skipped, and the run returns a `ScanSummary`
so the outcome is observable instead of only logged.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---
**Diff vs `main`:**  4 files changed, 551 insertions(+), 41 deletions(-)
Tests and `ruff check` pass on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)