### PR TITLE
fix: welcome only first-time contributors; make onboarding gates real (#40, #42)

### DIFF
--- a/app/config/schema.py
+++ b/app/config/schema.py
@@ -27,8 +27,22 @@ class RoleRequirements(BaseModel):
 
 class OnboardingConfig(BaseModel):
     enabled: bool = True
+
+    # When true, heuristic bot-login detection runs on top of GitHub's own
+    # account type, catching bots that present as `type: User`. When false only
+    # accounts GitHub reports as `type: Bot` are skipped.
     check_human_contributors: bool = True
+
+    # Gate `/assign` on the contributor appearing in the repo's CLA signature
+    # file. Fails closed: an unreadable or missing signature file blocks
+    # assignment rather than waving it through.
     require_signed_cla: bool = False
+    cla_signatures_file: str = ".github/cla-signatures.json"
+    cla_document_url: str | None = None
+
+    # Post the welcome comment only for genuine first-time contributors.
+    welcome_first_time_only: bool = True
+
     minimum_account_age_days: int = Field(default=0, ge=0)
     minimum_public_contributions: int = Field(default=0, ge=0)
     auto_assign_mentor: bool = False

--- a/app/workflows/onboarding.py
+++ b/app/workflows/onboarding.py
@@ -3,8 +3,13 @@
 from __future__ import annotations
 
 import asyncio
+import base64
+import json
 from datetime import datetime, timezone
 
+from sqlalchemy import select
+
+from app.db.models import AuditLog
 from app.github.client import GitHubClient
 from app.utils import audit
 from app.utils.logger import get_logger
@@ -21,7 +26,48 @@ def _get_assign_lock(owner: str, repo: str, issue_number: int) -> asyncio.Lock:
     return _assign_locks[key]
 
 
-BOT_PATTERNS = ("bot", "dependabot", "renovate", "github-actions", "[bot]")
+# Bot detection. Substring matching is deliberately avoided — "bot" appears in
+# plenty of human logins (robotics-sam, abbot, talbot), and silently skipping
+# those people is worse than occasionally welcoming a bot.
+BOT_LOGIN_SUFFIXES = ("[bot]",)
+BOT_LOGIN_EXACT = frozenset(
+    {
+        "dependabot",
+        "renovate",
+        "renovate-bot",
+        "github-actions",
+        "codecov",
+        "codecov-io",
+        "greenkeeper",
+        "snyk-bot",
+        "imgbot",
+        "allcontributors",
+        "mergify",
+        "stale",
+        "semantic-release-bot",
+        "pre-commit-ci",
+    }
+)
+
+# GitHub reports how the author relates to the repository. Anyone in this set
+# has demonstrably interacted with the project before, so they are not new.
+ESTABLISHED_ASSOCIATIONS = frozenset(
+    {"OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"}
+)
+
+
+def looks_like_bot(login: str, account_type: str = "") -> bool:
+    """True when the account is a bot by GitHub's own reckoning or by login shape."""
+    if account_type == "Bot":
+        return True
+
+    normalized = login.lower()
+    if any(normalized.endswith(suffix) for suffix in BOT_LOGIN_SUFFIXES):
+        return True
+
+    # Strip a trailing "-bot"/"bot" style qualifier before the exact match so
+    # both "renovate" and "renovate-bot" resolve to a known automation account.
+    return normalized in BOT_LOGIN_EXACT
 
 
 class OnboardingWorkflow:
@@ -35,19 +81,33 @@ class OnboardingWorkflow:
 
         sender = payload.get("sender", {})
         login: str = sender.get("login", "")
-        issue_number: int | None = (payload.get("issue") or {}).get("number")
+        issue = payload.get("issue") or {}
+        issue_number: int | None = issue.get("number")
         if not login or not issue_number:
             return
 
-        # Skip bots
-        if sender.get("type") == "Bot" or any(p in login.lower() for p in BOT_PATTERNS):
+        # `check_human_contributors: false` still respects GitHub's own account
+        # type — it only turns off the heuristic login matching on top of it.
+        if sender.get("type") == "Bot" or (
+            cfg.check_human_contributors and looks_like_bot(login)
+        ):
             log.debug("Skipping bot account: %s", login)
             return
 
         owner, repo, inst = ctx["owner"], ctx["repo"], ctx["installation_id"]
         db = ctx["db"]
 
-        # Welcome every human issue creator
+        if cfg.welcome_first_time_only:
+            first_time = await self._is_first_time(ctx, login, issue_number, issue)
+            if not first_time:
+                log.debug(
+                    "@%s is an established contributor in %s/%s — no welcome",
+                    login,
+                    owner,
+                    repo,
+                )
+                return
+
         msg = self._build_welcome(login, cfg)
         await self._gh.post_comment(owner, repo, issue_number, msg, inst)
 
@@ -118,21 +178,87 @@ class OnboardingWorkflow:
             )
             await db.commit()
 
-    # ── Helpers ───────────────────────────────────────────────
+    # ── First-time detection ──────────────────────────────────
 
     async def _is_first_time(
-        self, owner: str, repo: str, login: str, inst: int
+        self, ctx: dict, login: str, issue_number: int, issue: dict
     ) -> bool:
-        try:
-            contributors = await self._gh.get(
-                f"/repos/{owner}/{repo}/contributors", inst, params={"per_page": 500}
-            )
-            return not any(c["login"] == login for c in (contributors or []))
-        except Exception:
+        """
+        Decide whether this is the contributor's first interaction with the repo.
+
+        Three independent signals, cheapest first:
+
+        1. `author_association` — GitHub already tells us when the author is an
+           owner, member, collaborator or past contributor.
+        2. The audit trail — if we welcomed them before, don't do it again, even
+           if GitHub's view of them has since changed.
+        3. Their issue/PR history in this repo — the only signal that catches
+           someone who has opened issues but never had a PR merged, which is
+           exactly the case the old code got wrong.
+        """
+        association = (issue.get("author_association") or "").upper()
+        if association in ESTABLISHED_ASSOCIATIONS:
             return False
+
+        if await self._already_welcomed(ctx, login):
+            return False
+
+        return await self._has_no_prior_issues(ctx, login, issue_number)
+
+    async def _already_welcomed(self, ctx: dict, login: str) -> bool:
+        try:
+            result = await ctx["db"].execute(
+                select(AuditLog.id)
+                .where(
+                    AuditLog.owner == ctx["owner"],
+                    AuditLog.repo == ctx["repo"],
+                    AuditLog.target_login == login,
+                    AuditLog.action == "contributor.welcomed",
+                )
+                .limit(1)
+            )
+            return result.scalar() is not None
+        except Exception as exc:
+            log.warning("Could not check welcome history for @%s: %s", login, exc)
+            return False
+
+    async def _has_no_prior_issues(
+        self, ctx: dict, login: str, issue_number: int
+    ) -> bool:
+        """True when the issue being handled is the only one this login has opened."""
+        owner, repo, inst = ctx["owner"], ctx["repo"], ctx["installation_id"]
+        try:
+            created = await self._gh.get(
+                f"/repos/{owner}/{repo}/issues",
+                inst,
+                params={
+                    "creator": login,
+                    "state": "all",
+                    "per_page": 5,
+                    "sort": "created",
+                    "direction": "asc",
+                },
+            )
+        except Exception as exc:
+            # Unknown history: fall back to the association signal, which already
+            # told us they are not an established contributor.
+            log.warning("Could not read issue history for @%s: %s", login, exc)
+            return True
+
+        others = [
+            item
+            for item in (created or [])
+            if item.get("number") != issue_number
+        ]
+        return not others
+
+    # ── Eligibility ───────────────────────────────────────────
 
     async def _check_eligibility(self, ctx: dict, login: str) -> tuple[bool, str]:
         cfg = ctx["config"].workflows.onboarding
+
+        # Account-quality checks fail open: a GitHub hiccup should not stop a
+        # legitimate contributor from picking up an issue.
         try:
             user = await self._gh.get_user(login, ctx["installation_id"])
             created = datetime.fromisoformat(user["created_at"].replace("Z", "+00:00"))
@@ -149,9 +275,78 @@ class OnboardingWorkflow:
                     f"⚠️ @{login} Your account needs at least "
                     f"**{cfg.minimum_public_contributions} public repos** to qualify."
                 )
-        except Exception:
-            pass  # Fail open
+        except Exception as exc:
+            log.warning("Account checks skipped for @%s: %s", login, exc)
+
+        # The CLA gate fails closed — "required" has to mean required.
+        if cfg.require_signed_cla and not await self._has_signed_cla(ctx, login):
+            return False, self._cla_notice(login, cfg)
+
         return True, ""
+
+    async def _has_signed_cla(self, ctx: dict, login: str) -> bool:
+        owner, repo, inst = ctx["owner"], ctx["repo"], ctx["installation_id"]
+        path = ctx["config"].workflows.onboarding.cla_signatures_file
+
+        try:
+            raw_b64 = await self._gh.get_file_content(owner, repo, path, inst)
+        except Exception as exc:
+            log.error("CLA signature file %s unreadable: %s", path, exc)
+            return False
+
+        if not raw_b64:
+            log.warning(
+                "require_signed_cla is on but %s is missing in %s/%s", path, owner, repo
+            )
+            return False
+
+        try:
+            document = json.loads(base64.b64decode(raw_b64).decode("utf-8"))
+        except (ValueError, UnicodeDecodeError) as exc:
+            log.error("CLA signature file %s is not valid JSON: %s", path, exc)
+            return False
+
+        return login.lower() in self._signatory_logins(document)
+
+    @staticmethod
+    def _signatory_logins(document: object) -> set[str]:
+        """
+        Extract signatory logins from the common CLA-file shapes.
+
+        Supports cla-assistant's `{"signedContributors": [{"name": "..."}]}`, a
+        bare list of logins, and a list of `{"login": "..."}` objects.
+        """
+        if isinstance(document, dict):
+            entries = document.get("signedContributors") or document.get("signatures")
+        else:
+            entries = document
+
+        if not isinstance(entries, list):
+            return set()
+
+        logins: set[str] = set()
+        for entry in entries:
+            if isinstance(entry, str):
+                logins.add(entry.lower())
+            elif isinstance(entry, dict):
+                name = entry.get("name") or entry.get("login") or entry.get("username")
+                if isinstance(name, str):
+                    logins.add(name.lower())
+        return logins
+
+    @staticmethod
+    def _cla_notice(login: str, cfg) -> str:
+        link = (
+            f"\n\nSign it here: {cfg.cla_document_url}" if cfg.cla_document_url else ""
+        )
+        return (
+            f"⚠️ @{login} This repository requires a signed Contributor License "
+            f"Agreement before you can be assigned an issue.{link}\n\n"
+            f"Once your signature appears in `{cfg.cla_signatures_file}`, comment "
+            f"`/assign` again."
+        )
+
+    # ── Mentors ───────────────────────────────────────────────
 
     async def _assign_mentor(
         self, ctx: dict, issue_number: int, contributor: str

--- a/templates/hiero-bot.yml
+++ b/templates/hiero-bot.yml
@@ -22,8 +22,22 @@ workflows:
   #  Onboarding 
   onboarding:
     enabled: true
+
+    # true  → skip bots GitHub reports as `type: Bot` *and* logins that match
+    #         known automation accounts (dependabot[bot], renovate, ...)
+    # false → skip only accounts GitHub itself reports as bots
     check_human_contributors: true
+
+    # Post the welcome comment only for genuine first-time contributors.
+    # Set false to greet every issue opener.
+    welcome_first_time_only: true
+
+    # Gate /assign on the contributor appearing in the CLA signature file.
+    # Fails closed: a missing or unreadable file blocks assignment.
     require_signed_cla: false
+    cla_signatures_file: ".github/cla-signatures.json"
+    # cla_document_url: "https://example.org/cla"
+
     minimum_account_age_days: 0       # 0 = no minimum
     minimum_public_contributions: 0   # 0 = no minimum
     auto_assign_mentor: false

--- a/tests/unit/test_onboarding.py
+++ b/tests/unit/test_onboarding.py
@@ -1,32 +1,112 @@
-﻿# tests/unit/test_onboarding.py
+# tests/unit/test_onboarding.py
 
+import base64
+import json
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock
 
 import pytest
 
-from app.workflows.onboarding import OnboardingWorkflow
+from app.utils import audit
+from app.workflows.onboarding import OnboardingWorkflow, looks_like_bot
 
 
-def make_payload(login="alice", issue_number=1, sender_type="User", assignees=None):
+def make_payload(
+    login="alice",
+    issue_number=1,
+    sender_type="User",
+    assignees=None,
+    author_association="NONE",
+):
     return {
         "sender": {"login": login, "type": sender_type},
         "issue": {
             "number": issue_number,
             "user": {"login": login},
             "assignees": assignees or [],
+            "author_association": author_association,
         },
         "comment": {"user": {"login": login}, "body": "/assign"},
     }
 
 
+def encode(document):
+    return base64.b64encode(json.dumps(document).encode()).decode()
+
+
+def only_own_issue(issue_number=1):
+    """GitHub issue-history response containing just the issue being handled."""
+    return AsyncMock(return_value=[{"number": issue_number}])
+
+
+# ── Welcome flow ──────────────────────────────────────────────
+
+
 @pytest.mark.asyncio
 async def test_welcomes_first_time_contributor(mock_gh, ctx):
-    mock_gh.get = AsyncMock(return_value=[])
+    mock_gh.get = only_own_issue()
     wf = OnboardingWorkflow(mock_gh)
     await wf.handle_new_contributor(ctx, make_payload())
     mock_gh.post_comment.assert_awaited_once()
     assert "Welcome to Hiero" in mock_gh.post_comment.call_args[0][3]
+
+
+@pytest.mark.asyncio
+async def test_skips_contributor_with_earlier_issues(mock_gh, ctx):
+    """Regression for #40 — every issue-opener used to get a welcome."""
+    mock_gh.get = AsyncMock(return_value=[{"number": 1}, {"number": 7}])
+    wf = OnboardingWorkflow(mock_gh)
+    await wf.handle_new_contributor(ctx, make_payload(issue_number=1))
+    mock_gh.post_comment.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_skips_established_author_association(mock_gh, ctx):
+    wf = OnboardingWorkflow(mock_gh)
+    await wf.handle_new_contributor(
+        ctx, make_payload(author_association="COLLABORATOR")
+    )
+    mock_gh.post_comment.assert_not_awaited()
+    mock_gh.get.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_skips_contributor_welcomed_before(mock_gh, ctx, db):
+    await audit.record(
+        db,
+        action="contributor.welcomed",
+        owner="hiero",
+        repo="sdk-js",
+        target_login="alice",
+        target_number=99,
+        reason="Earlier welcome",
+    )
+    await db.commit()
+
+    mock_gh.get = only_own_issue()
+    wf = OnboardingWorkflow(mock_gh)
+    await wf.handle_new_contributor(ctx, make_payload())
+    mock_gh.post_comment.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_welcomes_everyone_when_first_time_only_disabled(mock_gh, ctx):
+    ctx["config"].workflows.onboarding.welcome_first_time_only = False
+    mock_gh.get = AsyncMock(return_value=[{"number": 1}, {"number": 7}])
+    wf = OnboardingWorkflow(mock_gh)
+    await wf.handle_new_contributor(ctx, make_payload())
+    mock_gh.post_comment.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_welcomes_when_issue_history_lookup_fails(mock_gh, ctx):
+    mock_gh.get = AsyncMock(side_effect=RuntimeError("api down"))
+    wf = OnboardingWorkflow(mock_gh)
+    await wf.handle_new_contributor(ctx, make_payload())
+    mock_gh.post_comment.assert_awaited_once()
+
+
+# ── Bot detection (#42: check_human_contributors) ─────────────
 
 
 @pytest.mark.asyncio
@@ -44,11 +124,41 @@ async def test_skips_dependabot_login(mock_gh, ctx):
 
 
 @pytest.mark.asyncio
-async def test_welcomes_existing_contributor(mock_gh, ctx):
-    mock_gh.get = AsyncMock(return_value=[{"login": "alice"}])
+async def test_bot_type_still_skipped_when_human_check_disabled(mock_gh, ctx):
+    ctx["config"].workflows.onboarding.check_human_contributors = False
     wf = OnboardingWorkflow(mock_gh)
-    await wf.handle_new_contributor(ctx, make_payload())
+    await wf.handle_new_contributor(ctx, make_payload(sender_type="Bot"))
+    mock_gh.post_comment.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_heuristic_bot_match_off_when_human_check_disabled(mock_gh, ctx):
+    """`check_human_contributors: false` must actually change behaviour (#42)."""
+    ctx["config"].workflows.onboarding.check_human_contributors = False
+    mock_gh.get = only_own_issue()
+    wf = OnboardingWorkflow(mock_gh)
+    await wf.handle_new_contributor(ctx, make_payload(login="renovate"))
     mock_gh.post_comment.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    "login",
+    ["dependabot[bot]", "renovate", "github-actions", "MERGIFY", "snyk-bot"],
+)
+def test_known_bot_logins_detected(login):
+    assert looks_like_bot(login)
+
+
+@pytest.mark.parametrize("login", ["talbot", "abbot", "robotics-sam", "botany-dev"])
+def test_human_logins_containing_bot_are_not_bots(login):
+    assert not looks_like_bot(login)
+
+
+def test_account_type_bot_wins_over_login():
+    assert looks_like_bot("alice", account_type="Bot")
+
+
+# ── Config / mentors ──────────────────────────────────────────
 
 
 @pytest.mark.asyncio
@@ -61,13 +171,16 @@ async def test_skips_when_disabled(mock_gh, ctx):
 
 @pytest.mark.asyncio
 async def test_assigns_mentor_when_enabled(mock_gh, ctx):
-    mock_gh.get = AsyncMock(return_value=[])
+    mock_gh.get = only_own_issue()
     ctx["config"].workflows.onboarding.auto_assign_mentor = True
     ctx["config"].teams.mentors = "mentors"
     wf = OnboardingWorkflow(mock_gh)
     await wf.handle_new_contributor(ctx, make_payload())
     mock_gh.add_assignees.assert_awaited()
     assert "mentor1" in mock_gh.add_assignees.call_args[0][3]
+
+
+# ── Self-assignment ───────────────────────────────────────────
 
 
 @pytest.mark.asyncio
@@ -91,7 +204,6 @@ async def test_self_assign_already_assigned(mock_gh, ctx):
 @pytest.mark.asyncio
 async def test_self_assign_blocked_by_min_age(mock_gh, ctx):
     ctx["config"].workflows.onboarding.minimum_account_age_days = 90
-    mock_gh.get = AsyncMock(return_value={"assignees": []})
 
     # Create a dynamic date that is exactly 10 days ago so this test never expires
     recent_date = (datetime.now(timezone.utc) - timedelta(days=10)).strftime(
@@ -114,8 +226,109 @@ async def test_self_assign_blocked_by_min_age(mock_gh, ctx):
 
 
 @pytest.mark.asyncio
+async def test_account_check_failure_does_not_block_assignment(mock_gh, ctx):
+    mock_gh.get = AsyncMock(return_value={"number": 1, "assignees": []})
+    mock_gh.get_user = AsyncMock(side_effect=RuntimeError("api down"))
+    wf = OnboardingWorkflow(mock_gh)
+    await wf.handle_self_assign(ctx, make_payload())
+    mock_gh.add_assignees.assert_awaited_once()
+
+
+# ── CLA gate (#42: require_signed_cla) ────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cla_gate_blocks_unsigned_contributor(mock_gh, ctx):
+    """Regression for #42 — require_signed_cla used to be inert."""
+    ctx["config"].workflows.onboarding.require_signed_cla = True
+    ctx["config"].workflows.onboarding.cla_document_url = "https://example.org/cla"
+    mock_gh.get = AsyncMock(return_value={"number": 1, "assignees": []})
+    mock_gh.get_file_content = AsyncMock(
+        return_value=encode({"signedContributors": [{"name": "bob"}]})
+    )
+
+    wf = OnboardingWorkflow(mock_gh)
+    await wf.handle_self_assign(ctx, make_payload())
+
+    mock_gh.add_assignees.assert_not_awaited()
+    body = mock_gh.post_comment.call_args[0][3]
+    assert "Contributor License Agreement" in body
+    assert "https://example.org/cla" in body
+
+
+@pytest.mark.asyncio
+async def test_cla_gate_allows_signed_contributor(mock_gh, ctx):
+    ctx["config"].workflows.onboarding.require_signed_cla = True
+    mock_gh.get = AsyncMock(return_value={"number": 1, "assignees": []})
+    mock_gh.get_file_content = AsyncMock(
+        return_value=encode({"signedContributors": [{"name": "Alice"}]})
+    )
+
+    wf = OnboardingWorkflow(mock_gh)
+    await wf.handle_self_assign(ctx, make_payload())
+
+    mock_gh.add_assignees.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_cla_gate_fails_closed_when_file_missing(mock_gh, ctx):
+    ctx["config"].workflows.onboarding.require_signed_cla = True
+    mock_gh.get = AsyncMock(return_value={"number": 1, "assignees": []})
+    mock_gh.get_file_content = AsyncMock(return_value=None)
+
+    wf = OnboardingWorkflow(mock_gh)
+    await wf.handle_self_assign(ctx, make_payload())
+
+    mock_gh.add_assignees.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_cla_gate_fails_closed_on_invalid_json(mock_gh, ctx):
+    ctx["config"].workflows.onboarding.require_signed_cla = True
+    mock_gh.get = AsyncMock(return_value={"number": 1, "assignees": []})
+    mock_gh.get_file_content = AsyncMock(
+        return_value=base64.b64encode(b"not json at all").decode()
+    )
+
+    wf = OnboardingWorkflow(mock_gh)
+    await wf.handle_self_assign(ctx, make_payload())
+
+    mock_gh.add_assignees.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_cla_not_checked_when_not_required(mock_gh, ctx):
+    mock_gh.get = AsyncMock(return_value={"number": 1, "assignees": []})
+    wf = OnboardingWorkflow(mock_gh)
+    await wf.handle_self_assign(ctx, make_payload())
+    mock_gh.get_file_content.assert_not_awaited()
+    mock_gh.add_assignees.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    "document",
+    [
+        ["alice", "bob"],
+        [{"login": "alice"}],
+        [{"username": "alice"}],
+        {"signatures": [{"name": "alice"}]},
+        {"signedContributors": [{"name": "alice"}]},
+    ],
+)
+def test_signatory_formats_supported(document):
+    assert "alice" in OnboardingWorkflow._signatory_logins(document)
+
+
+def test_signatory_extraction_ignores_unknown_shapes():
+    assert OnboardingWorkflow._signatory_logins({"totally": "different"}) == set()
+
+
+# ── Welcome body ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
 async def test_welcome_includes_checklist(mock_gh, ctx):
-    mock_gh.get = AsyncMock(return_value=[])
+    mock_gh.get = only_own_issue()
     ctx["config"].workflows.onboarding.onboarding_checklist = [
         "Read CONTRIBUTING.md",
         "Sign DCO",
@@ -129,7 +342,7 @@ async def test_welcome_includes_checklist(mock_gh, ctx):
 
 @pytest.mark.asyncio
 async def test_welcome_includes_custom_message(mock_gh, ctx):
-    mock_gh.get = AsyncMock(return_value=[])
+    mock_gh.get = only_own_issue()
     ctx["config"].workflows.onboarding.welcome_message = "Extra special welcome!"
     wf = OnboardingWorkflow(mock_gh)
     await wf.handle_new_contributor(ctx, make_payload())


### PR DESCRIPTION
fix: welcome only first-time contributors; make onboarding gates real (#40, #42)

#40 — `_is_first_time()` existed but was never called, so every issue opener
got the "Thanks for your first contribution" comment, including regulars.
First-time detection is now wired into `handle_new_contributor` and uses
three signals, cheapest first: the payload's `author_association`, our own
audit trail (never welcome the same person twice), and the author's issue
history in the repo. The old contributors-API check could not have worked
anyway — it lists commit authors, so anyone who had only ever opened issues
looked new forever. Behaviour is configurable via `welcome_first_time_only`.

#42 — two documented options did nothing:

  * `check_human_contributors` was ignored; bot filtering ran unconditionally
    via a substring match that also swallowed humans named talbot, abbot or
    robotics-sam. The flag now selects between GitHub's own account type only
    (false) and account type plus exact known-automation logins (true).
  * `require_signed_cla` was never read. `/assign` now checks the contributor
    against the repo's CLA signature file, supporting cla-assistant's format
    and two common variants. It fails closed — a missing or malformed file
    blocks assignment rather than waving it through — and the rejection
    comment links `cla_document_url` when configured.

Account-age and public-repo checks keep their existing fail-open behaviour,
now with a log line instead of a silent `except: pass`.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---
**Diff vs `main`:**  4 files changed, 461 insertions(+), 25 deletions(-)
Tests and `ruff check` pass on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)