### PR TITLE
perf: recommend reviewers from directory history, not 50 PR file listings (#45)

### DIFF
--- a/app/github/client.py
+++ b/app/github/client.py
@@ -462,5 +462,30 @@ class GitHubClient:
         except Exception as exc:
             log.warning("Inline comment failed (path=%s line=%d): %s", path, line, exc)
 
+    async def list_commits(
+        self,
+        owner: str,
+        repo: str,
+        installation_id: int,
+        *,
+        path: str | None = None,
+        per_page: int = 30,
+    ) -> list[dict]:
+        """
+        Recent commits on the default branch, optionally scoped to one path.
+
+        Scoping by path is what makes reviewer recommendation cheap: GitHub does
+        the history walk server-side and returns only the commits that touched
+        that directory, so one request answers "who has worked here lately".
+        """
+        params: dict[str, Any] = {"per_page": per_page}
+        if path:
+            params["path"] = path
+
+        result = await self.get(
+            f"/repos/{owner}/{repo}/commits", installation_id, params=params
+        )
+        return result if isinstance(result, list) else []
+
     async def close(self) -> None:
         await self._http.aclose()

--- a/app/workflows/pullrequest.py
+++ b/app/workflows/pullrequest.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import re
 
 from app.ai.reviewer import AIReviewer
+from app.db.models import ReviewerRecommendation
 from app.github.client import GitHubClient
 from app.utils import audit
 from app.utils.logger import get_logger
@@ -13,6 +15,13 @@ log = get_logger("workflow.pullrequest")
 
 LABEL_PASS = "quality: ✅ passed"
 LABEL_FAIL = "quality: ❌ needs work"
+
+# Reviewer recommendation budget. A PR spreading across more than a handful of
+# directories has no sharp ownership signal, so querying more of them buys
+# noise rather than accuracy — and every extra directory is another API call.
+MAX_PATHS_QUERIED = 5
+COMMITS_PER_PATH = 30
+MAX_RECOMMENDATIONS = 2
 
 
 class QualityCheck:
@@ -369,43 +378,62 @@ class PullRequestWorkflow:
     # ── Reviewer recommendation ───────────────────────────────
 
     async def _recommend_reviewers(self, ctx: dict, pr: dict) -> None:
-        """Suggest reviewers based on recent contribution history."""
+        """
+        Suggest reviewers from the commit history of the directories this PR touches.
+
+        The previous implementation listed the 50 most recent closed PRs and
+        then fetched the file list of every one of them — up to 51 API calls per
+        opened PR, serially, and it only ever saw whoever *authored* those PRs
+        rather than who reviewed them. This asks GitHub for the commit history of
+        each touched directory instead: a handful of concurrent requests, and the
+        answer is real file history rather than a proxy for it.
+        """
         owner, repo, inst = ctx["owner"], ctx["repo"], ctx["installation_id"]
         pr_number = pr["number"]
         author = pr["user"]["login"]
 
         try:
             files = await self._gh.list_pr_files(owner, repo, pr_number, inst)
-            touched_paths = [f["filename"] for f in files]
+            directories = _touched_directories(files)
+            if not directories:
+                return
 
-            # Get recent closed PRs touching same paths
-            recent_prs = await self._gh.get(
-                f"/repos/{owner}/{repo}/pulls",
-                inst,
-                params={"state": "closed", "per_page": 50},
+            histories = await asyncio.gather(
+                *(
+                    self._gh.list_commits(
+                        owner, repo, inst, path=directory, per_page=COMMITS_PER_PATH
+                    )
+                    for directory in directories
+                ),
+                return_exceptions=True,
             )
 
-            scores: dict[str, float] = {}
-            for rpr in recent_prs or []:
-                reviewer = (rpr.get("user") or {}).get("login", "")
-                if not reviewer or reviewer == author:
-                    continue
-                pr_files = await self._gh.list_pr_files(
-                    owner, repo, rpr["number"], inst
-                )
-                overlap = sum(
-                    1
-                    for f in pr_files
-                    if any(f["filename"].rsplit("/", 1)[0] in p for p in touched_paths)
-                )
-                if overlap:
-                    scores[reviewer] = scores.get(reviewer, 0) + overlap
-
+            scores = _score_candidates(histories, exclude=author)
             if not scores:
                 return
 
-            top = sorted(scores.items(), key=lambda x: x[1], reverse=True)[:2]
-            names = ", ".join(f"@{r}" for r, _ in top)
+            top = sorted(scores.items(), key=lambda item: item[1], reverse=True)[
+                :MAX_RECOMMENDATIONS
+            ]
+            best = top[0][1]
+
+            for login, hits in top:
+                ctx["db"].add(
+                    ReviewerRecommendation(
+                        owner=owner,
+                        repo=repo,
+                        pr_number=pr_number,
+                        recommended_reviewer=login,
+                        reason=(
+                            f"{hits} recent commit(s) in "
+                            f"{', '.join(sorted(directories))}"
+                        ),
+                        score=round(hits / best, 3),
+                        was_assigned=False,
+                    )
+                )
+
+            names = ", ".join(f"@{login}" for login, _ in top)
             await self._gh.post_comment(
                 owner,
                 repo,
@@ -420,11 +448,55 @@ class PullRequestWorkflow:
                 owner=owner,
                 repo=repo,
                 target_number=pr_number,
-                reason="Reviewer recommendation based on file overlap",
-                metadata={"recommendations": [r for r, _ in top]},
+                reason="Reviewer recommendation based on directory commit history",
+                metadata={
+                    "recommendations": [login for login, _ in top],
+                    "directories": sorted(directories),
+                    "api_calls": len(directories) + 1,
+                },
             )
         except Exception as exc:
             log.warning("Reviewer recommendation failed: %s", exc)
+
+
+def _touched_directories(files: list[dict]) -> list[str]:
+    """
+    The directories this PR changes, most-touched first, capped.
+
+    Files at the repository root collapse to "", which GitHub rejects as a path
+    filter, so they are dropped — a root-only PR has no meaningful ownership
+    signal to extract anyway.
+    """
+    counts: dict[str, int] = {}
+    for f in files:
+        filename = f.get("filename") or ""
+        if "/" not in filename:
+            continue
+        directory = filename.rsplit("/", 1)[0]
+        counts[directory] = counts.get(directory, 0) + 1
+
+    ranked = sorted(counts.items(), key=lambda item: item[1], reverse=True)
+    return [directory for directory, _ in ranked[:MAX_PATHS_QUERIED]]
+
+
+def _score_candidates(histories: list, exclude: str) -> dict[str, int]:
+    """Count commits per author across the fetched histories, skipping bots."""
+    scores: dict[str, int] = {}
+
+    for history in histories:
+        if isinstance(history, BaseException):
+            log.debug("Commit history lookup failed: %s", history)
+            continue
+
+        for commit in history or []:
+            login = ((commit.get("author") or {}).get("login") or "").strip()
+            if not login or login == exclude:
+                continue
+            if login.lower().endswith("[bot]"):
+                continue
+            scores[login] = scores.get(login, 0) + 1
+
+    return scores
 
 
 def _sev_emoji(sev: str) -> str:

--- a/app/workflows/pullrequest.py
+++ b/app/workflows/pullrequest.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 import re
 
+from sqlalchemy import select
+
 from app.ai.reviewer import AIReviewer
 from app.db.models import ReviewerRecommendation
 from app.github.client import GitHubClient
@@ -418,20 +420,36 @@ class PullRequestWorkflow:
             best = top[0][1]
 
             for login, hits in top:
-                ctx["db"].add(
-                    ReviewerRecommendation(
-                        owner=owner,
-                        repo=repo,
-                        pr_number=pr_number,
-                        recommended_reviewer=login,
-                        reason=(
-                            f"{hits} recent commit(s) in "
-                            f"{', '.join(sorted(directories))}"
-                        ),
-                        score=round(hits / best, 3),
-                        was_assigned=False,
+                reason = (
+                    f"{hits} recent commit(s) in "
+                    f"{', '.join(sorted(directories))}"
+                )
+                score = round(hits / best, 3)
+
+                existing = await ctx["db"].scalar(
+                    select(ReviewerRecommendation).where(
+                        ReviewerRecommendation.owner == owner,
+                        ReviewerRecommendation.repo == repo,
+                        ReviewerRecommendation.pr_number == pr_number,
+                        ReviewerRecommendation.recommended_reviewer == login,
                     )
                 )
+
+                if existing is None:
+                    ctx["db"].add(
+                        ReviewerRecommendation(
+                            owner=owner,
+                            repo=repo,
+                            pr_number=pr_number,
+                            recommended_reviewer=login,
+                            reason=reason,
+                            score=score,
+                            was_assigned=False,
+                        )
+                    )
+                else:
+                    existing.reason = reason
+                    existing.score = score
 
             names = ", ".join(f"@{login}" for login, _ in top)
             await self._gh.post_comment(
@@ -475,13 +493,17 @@ def _touched_directories(files: list[dict]) -> list[str]:
         directory = filename.rsplit("/", 1)[0]
         counts[directory] = counts.get(directory, 0) + 1
 
-    ranked = sorted(counts.items(), key=lambda item: item[1], reverse=True)
+    ranked = sorted(
+        counts.items(),
+        key=lambda item: (-item[1], item[0]),
+    )
     return [directory for directory, _ in ranked[:MAX_PATHS_QUERIED]]
 
 
 def _score_candidates(histories: list, exclude: str) -> dict[str, int]:
-    """Count commits per author across the fetched histories, skipping bots."""
+    """Count unique commits per author across the fetched histories, skipping bots."""
     scores: dict[str, int] = {}
+    seen_shas: set[str] = set()
 
     for history in histories:
         if isinstance(history, BaseException):
@@ -489,6 +511,12 @@ def _score_candidates(histories: list, exclude: str) -> dict[str, int]:
             continue
 
         for commit in history or []:
+            sha = commit.get("sha")
+            if sha:
+                if sha in seen_shas:
+                    continue
+                seen_shas.add(sha)
+
             login = ((commit.get("author") or {}).get("login") or "").strip()
             if not login or login == exclude:
                 continue

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -155,3 +155,39 @@ async def test_list_issue_comments_paginates():
     assert mock_get.await_count == 2
 
     await client.close()
+
+@pytest.mark.asyncio
+async def test_list_commits_uses_path_and_per_page():
+    client = GitHubClient()
+
+    with patch.object(
+        client,
+        "get",
+        new=AsyncMock(
+            return_value=[
+                {"sha": "abc123", "author": {"login": "bob"}},
+            ]
+        ),
+    ) as mock_get:
+        commits = await client.list_commits(
+            "hiero",
+            "sdk-js",
+            123,
+            path="app/github",
+            per_page=30,
+        )
+
+    assert commits == [
+        {"sha": "abc123", "author": {"login": "bob"}},
+    ]
+
+    mock_get.assert_awaited_once_with(
+        "/repos/hiero/sdk-js/commits",
+        123,
+        params={
+            "path": "app/github",
+            "per_page": 30,
+        },
+    )
+
+    await client.close()

--- a/tests/unit/test_reviewer_recommendation.py
+++ b/tests/unit/test_reviewer_recommendation.py
@@ -1,0 +1,212 @@
+# tests/unit/test_reviewer_recommendation.py — PR reviewer suggestions (#45)
+
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy import select
+
+from app.db.models import ReviewerRecommendation
+from app.workflows.pullrequest import (
+    MAX_PATHS_QUERIED,
+    PullRequestWorkflow,
+    _score_candidates,
+    _touched_directories,
+)
+
+
+def pr(number=7, author="alice"):
+    return {"number": number, "user": {"login": author}}
+
+
+def files(*names):
+    return [{"filename": name} for name in names]
+
+
+def commits(*logins):
+    return [{"author": {"login": login}} for login in logins]
+
+
+def suggestion_bodies(mock_gh):
+    return [
+        call[0][3]
+        for call in mock_gh.post_comment.call_args_list
+        if "Suggested reviewers" in call[0][3]
+    ]
+
+
+# ── Directory extraction ──────────────────────────────────────
+
+
+def test_directories_ranked_by_change_count():
+    changed = files(
+        "app/github/client.py",
+        "app/github/webhooks.py",
+        "tests/unit/test_x.py",
+    )
+    assert _touched_directories(changed)[0] == "app/github"
+
+
+def test_root_level_files_are_dropped():
+    assert _touched_directories(files("README.md", "setup.py")) == []
+
+
+def test_directory_list_is_capped():
+    changed = files(*[f"pkg{i}/mod.py" for i in range(20)])
+    assert len(_touched_directories(changed)) == MAX_PATHS_QUERIED
+
+
+def test_missing_filename_is_tolerated():
+    assert _touched_directories([{}, {"filename": "app/x.py"}]) == ["app"]
+
+
+# ── Scoring ───────────────────────────────────────────────────
+
+
+def test_scores_count_commits_per_author():
+    scores = _score_candidates([commits("bob", "bob", "carol")], exclude="alice")
+    assert scores == {"bob": 2, "carol": 1}
+
+
+def test_pr_author_is_excluded():
+    scores = _score_candidates([commits("alice", "bob")], exclude="alice")
+    assert "alice" not in scores
+
+
+def test_bot_committers_are_excluded():
+    scores = _score_candidates(
+        [commits("dependabot[bot]", "bob")], exclude="alice"
+    )
+    assert scores == {"bob": 1}
+
+
+def test_failed_history_lookup_does_not_break_scoring():
+    scores = _score_candidates(
+        [RuntimeError("403"), commits("bob")], exclude="alice"
+    )
+    assert scores == {"bob": 1}
+
+
+def test_commits_without_a_linked_account_are_skipped():
+    scores = _score_candidates(
+        [[{"author": None}, {"author": {"login": ""}}, *commits("bob")]],
+        exclude="alice",
+    )
+    assert scores == {"bob": 1}
+
+
+# ── End-to-end ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_one_request_per_directory_not_per_pr(mock_gh, ctx):
+    """Regression for #45 — this used to cost up to 51 calls per opened PR."""
+    mock_gh.list_pr_files = AsyncMock(
+        return_value=files("app/github/client.py", "app/db/models.py")
+    )
+    mock_gh.list_commits = AsyncMock(return_value=commits("bob"))
+
+    wf = PullRequestWorkflow(mock_gh)
+    await wf._recommend_reviewers(ctx, pr())
+
+    assert mock_gh.list_commits.await_count == 2
+    assert mock_gh.list_pr_files.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_suggests_the_most_active_committers(mock_gh, ctx):
+    mock_gh.list_pr_files = AsyncMock(return_value=files("app/github/client.py"))
+    mock_gh.list_commits = AsyncMock(
+        return_value=commits("bob", "bob", "bob", "carol", "dave")
+    )
+
+    wf = PullRequestWorkflow(mock_gh)
+    await wf._recommend_reviewers(ctx, pr())
+
+    body = suggestion_bodies(mock_gh)[0]
+    assert "@bob" in body
+    assert "@carol" in body
+    assert "@dave" not in body
+
+
+@pytest.mark.asyncio
+async def test_recommendations_are_persisted(mock_gh, ctx, db):
+    mock_gh.list_pr_files = AsyncMock(return_value=files("app/github/client.py"))
+    mock_gh.list_commits = AsyncMock(return_value=commits("bob", "bob", "carol"))
+
+    wf = PullRequestWorkflow(mock_gh)
+    await wf._recommend_reviewers(ctx, pr(number=7))
+    await db.commit()
+
+    rows = (await db.execute(select(ReviewerRecommendation))).scalars().all()
+
+    assert {row.recommended_reviewer for row in rows} == {"bob", "carol"}
+    assert all(row.pr_number == 7 for row in rows)
+    top = next(row for row in rows if row.recommended_reviewer == "bob")
+    assert top.score == 1.0
+    assert "app/github" in top.reason
+
+
+@pytest.mark.asyncio
+async def test_no_comment_when_nobody_qualifies(mock_gh, ctx):
+    mock_gh.list_pr_files = AsyncMock(return_value=files("app/github/client.py"))
+    mock_gh.list_commits = AsyncMock(return_value=commits("alice"))
+
+    wf = PullRequestWorkflow(mock_gh)
+    await wf._recommend_reviewers(ctx, pr(author="alice"))
+
+    assert suggestion_bodies(mock_gh) == []
+
+
+@pytest.mark.asyncio
+async def test_root_only_pr_makes_no_history_calls(mock_gh, ctx):
+    mock_gh.list_pr_files = AsyncMock(return_value=files("README.md"))
+
+    wf = PullRequestWorkflow(mock_gh)
+    await wf._recommend_reviewers(ctx, pr())
+
+    mock_gh.list_commits.assert_not_awaited()
+    assert suggestion_bodies(mock_gh) == []
+
+
+@pytest.mark.asyncio
+async def test_history_failure_is_swallowed(mock_gh, ctx):
+    mock_gh.list_pr_files = AsyncMock(return_value=files("app/x.py"))
+    mock_gh.list_commits = AsyncMock(side_effect=RuntimeError("403"))
+
+    wf = PullRequestWorkflow(mock_gh)
+    await wf._recommend_reviewers(ctx, pr())
+
+    assert suggestion_bodies(mock_gh) == []
+
+
+@pytest.mark.asyncio
+async def test_file_listing_failure_is_swallowed(mock_gh, ctx):
+    mock_gh.list_pr_files = AsyncMock(side_effect=RuntimeError("boom"))
+
+    wf = PullRequestWorkflow(mock_gh)
+    await wf._recommend_reviewers(ctx, pr())
+
+    assert suggestion_bodies(mock_gh) == []
+
+
+@pytest.mark.asyncio
+async def test_audit_records_the_call_budget(mock_gh, ctx, db):
+    from app.db.models import AuditLog
+
+    mock_gh.list_pr_files = AsyncMock(
+        return_value=files("app/a/x.py", "app/b/y.py")
+    )
+    mock_gh.list_commits = AsyncMock(return_value=commits("bob"))
+
+    wf = PullRequestWorkflow(mock_gh)
+    await wf._recommend_reviewers(ctx, pr())
+    await db.commit()
+
+    entry = (
+        await db.execute(
+            select(AuditLog).where(AuditLog.action == "pr.reviewer_recommended")
+        )
+    ).scalar_one()
+
+    assert entry.metadata_json["api_calls"] == 3
+    assert entry.metadata_json["directories"] == ["app/a", "app/b"]

--- a/tests/unit/test_reviewer_recommendation.py
+++ b/tests/unit/test_reviewer_recommendation.py
@@ -46,6 +46,25 @@ def test_directories_ranked_by_change_count():
     assert _touched_directories(changed)[0] == "app/github"
 
 
+def test_directories_use_deterministic_tie_breaking():
+    changed = files(
+        "pkg/zeta/mod.py",
+        "pkg/alpha/mod.py",
+        "pkg/gamma/mod.py",
+        "pkg/beta/mod.py",
+        "pkg/epsilon/mod.py",
+        "pkg/delta/mod.py",
+    )
+
+    assert _touched_directories(changed) == [
+        "pkg/alpha",
+        "pkg/beta",
+        "pkg/delta",
+        "pkg/epsilon",
+        "pkg/gamma",
+    ]
+
+
 def test_root_level_files_are_dropped():
     assert _touched_directories(files("README.md", "setup.py")) == []
 
@@ -65,6 +84,23 @@ def test_missing_filename_is_tolerated():
 def test_scores_count_commits_per_author():
     scores = _score_candidates([commits("bob", "bob", "carol")], exclude="alice")
     assert scores == {"bob": 2, "carol": 1}
+
+
+def test_duplicate_commits_across_histories_are_counted_once():
+    duplicate = {
+        "sha": "abc123",
+        "author": {"login": "bob"},
+    }
+
+    scores = _score_candidates(
+        [
+            [duplicate],
+            [duplicate],
+        ],
+        exclude="alice",
+    )
+
+    assert scores == {"bob": 1}
 
 
 def test_pr_author_is_excluded():
@@ -113,6 +149,33 @@ async def test_one_request_per_directory_not_per_pr(mock_gh, ctx):
 
 
 @pytest.mark.asyncio
+async def test_recommendation_has_hard_six_request_api_ceiling(mock_gh, ctx):
+    mock_gh.list_pr_files = AsyncMock(
+        return_value=files(
+            "pkg0/mod.py",
+            "pkg1/mod.py",
+            "pkg2/mod.py",
+            "pkg3/mod.py",
+            "pkg4/mod.py",
+            "pkg5/mod.py",
+            "pkg6/mod.py",
+        )
+    )
+    mock_gh.list_commits = AsyncMock(return_value=commits("bob"))
+
+    wf = PullRequestWorkflow(mock_gh)
+    await wf._recommend_reviewers(ctx, pr())
+
+    assert mock_gh.list_pr_files.await_count == 1
+    assert mock_gh.list_commits.await_count == MAX_PATHS_QUERIED
+    assert (
+        mock_gh.list_pr_files.await_count
+        + mock_gh.list_commits.await_count
+        == MAX_PATHS_QUERIED + 1
+    )
+
+
+@pytest.mark.asyncio
 async def test_suggests_the_most_active_committers(mock_gh, ctx):
     mock_gh.list_pr_files = AsyncMock(return_value=files("app/github/client.py"))
     mock_gh.list_commits = AsyncMock(
@@ -144,6 +207,75 @@ async def test_recommendations_are_persisted(mock_gh, ctx, db):
     top = next(row for row in rows if row.recommended_reviewer == "bob")
     assert top.score == 1.0
     assert "app/github" in top.reason
+
+
+@pytest.mark.asyncio
+async def test_recommendations_are_updated_on_repeat(
+    mock_gh,
+    ctx,
+    db,
+):
+    mock_gh.list_pr_files = AsyncMock(
+        return_value=files("app/github/client.py")
+    )
+    mock_gh.list_commits = AsyncMock(
+        return_value=commits("bob", "bob", "carol")
+    )
+
+    wf = PullRequestWorkflow(mock_gh)
+
+    await wf._recommend_reviewers(ctx, pr(number=7))
+    await db.commit()
+
+    first_rows = (
+        await db.execute(
+            select(ReviewerRecommendation).where(
+                ReviewerRecommendation.pr_number == 7
+            )
+        )
+    ).scalars().all()
+
+    first_bob = next(
+        row for row in first_rows
+        if row.recommended_reviewer == "bob"
+    )
+    first_carol = next(
+        row for row in first_rows
+        if row.recommended_reviewer == "carol"
+    )
+
+    assert len(first_rows) == 2
+    assert first_bob.score == 1.0
+    assert first_carol.score == 0.5
+
+    mock_gh.list_commits = AsyncMock(
+        return_value=commits("bob", "carol", "carol")
+    )
+
+    await wf._recommend_reviewers(ctx, pr(number=7))
+    await db.commit()
+
+    rows = (
+        await db.execute(
+            select(ReviewerRecommendation).where(
+                ReviewerRecommendation.pr_number == 7
+            )
+        )
+    ).scalars().all()
+
+    assert len(rows) == 2
+
+    bob = next(
+        row for row in rows
+        if row.recommended_reviewer == "bob"
+    )
+    carol = next(
+        row for row in rows
+        if row.recommended_reviewer == "carol"
+    )
+
+    assert bob.score == 0.5
+    assert carol.score == 1.0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
perf: recommend reviewers from directory history, not 50 PR file listings (#45)

Opening a pull request cost up to 51 GitHub API calls. `_recommend_reviewers`
listed the 50 most recent closed PRs, then fetched the file list of each one,
serially, to look for path overlap. On a busy repo that is a meaningful slice
of an installation's hourly rate limit spent on every single PR — and the
signal it produced was whoever *authored* those PRs, not who knows the code.

Replaced with one `GET /repos/:o/:r/commits?path=<dir>` per touched directory,
issued concurrently and capped at five directories: a handful of calls, and
the result is the actual commit history of the code being changed. Bots and
the PR author are filtered out of the candidate pool.

The `ReviewerRecommendation` table has existed since the schema was written
but nothing ever wrote to it. Recommendations are now persisted with a reason
and a normalised confidence score, so the dashboard and API can show why a
name was suggested. The audit entry records the call budget the run actually
spent.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---
**Diff vs `main`:**  3 files changed, 336 insertions(+), 27 deletions(-)
Tests and `ruff check` pass on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)