### PR TITLE
feat: rate limit /webhook and /api/v1 (#19)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,3 +34,12 @@ OPENAI_API_KEY=
 # Webhook Skew Guard
 WEBHOOK_MAX_SKEW_SECONDS=300
 
+# Rate limiting (per process, per caller IP)
+RATE_LIMIT_ENABLED=true
+RATE_LIMIT_WEBHOOK_PER_MINUTE=600
+RATE_LIMIT_API_PER_MINUTE=120
+RATE_LIMIT_BURST=0            # 0 = burst equals the per-minute budget
+
+# Proxies in front of this app. 0 ignores X-Forwarded-For (a client can forge
+# it); set to the number of trusted hops when running behind nginx/Cloudflare.
+TRUSTED_PROXY_HOPS=0

--- a/app/main.py
+++ b/app/main.py
@@ -20,6 +20,7 @@ from app.github.webhooks import WebhookRouter
 from app.scheduler.jobs import BotScheduler
 from app.utils.auth import _auth_configured
 from app.utils.logger import get_logger
+from app.utils.ratelimit import RateLimitMiddleware
 from app.utils.settings import settings
 
 log = get_logger("main")
@@ -83,7 +84,6 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-
 # Security Headers Middleware
 @app.middleware("http")
 async def add_security_headers(request: Request, call_next):
@@ -92,19 +92,29 @@ async def add_security_headers(request: Request, call_next):
     response.headers["X-Frame-Options"] = "DENY"
     response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
     if settings.is_production:
-        response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
+        response.headers["Strict-Transport-Security"] = (
+            "max-age=31536000; includeSubDomains"
+        )
     return response
 
 
 # Global Exception Handler
 @app.exception_handler(Exception)
 async def global_exception_handler(request: Request, exc: Exception):
-    log.error("Unhandled server exception on %s %s: %s", request.method, request.url.path, exc, exc_info=exc)
+    log.error(
+        "Unhandled server exception on %s %s: %s",
+        request.method,
+        request.url.path,
+        exc,
+        exc_info=exc,
+    )
     return JSONResponse(
         status_code=500,
         content={"detail": "An internal server error occurred."},
     )
 
+
+app.add_middleware(RateLimitMiddleware)
 
 from app.auth.dependencies import get_current_user_optional
 from app.db.models import User
@@ -163,4 +173,3 @@ async def healthz(db: AsyncSession = Depends(get_db)):
             "environment": settings.environment,
         },
     )
-

--- a/app/utils/ratelimit.py
+++ b/app/utils/ratelimit.py
@@ -1,0 +1,185 @@
+# app/utils/ratelimit.py — Token-bucket rate limiting for public endpoints
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+from app.utils.logger import get_logger
+from app.utils.settings import settings
+
+log = get_logger("utils.ratelimit")
+
+# Paths that must never be throttled: a load balancer polling health should not
+# be able to lock itself out, and it carries no cost worth protecting.
+EXEMPT_PATHS = frozenset({"/healthz"})
+
+# Buckets are pruned once the table grows past this, so a spray of requests from
+# many source addresses cannot grow the process's memory without limit.
+_PRUNE_THRESHOLD = 10_000
+
+
+@dataclass
+class Bucket:
+    """A token bucket: `tokens` refill at `rate` per second, capped at `burst`."""
+
+    tokens: float
+    updated_at: float
+
+    def take(self, *, rate: float, burst: float, now: float) -> bool:
+        elapsed = now - self.updated_at
+        self.tokens = min(burst, self.tokens + elapsed * rate)
+        self.updated_at = now
+
+        if self.tokens < 1.0:
+            return False
+
+        self.tokens -= 1.0
+        return True
+
+    def retry_after(self, *, rate: float, now: float) -> int:
+        """Whole seconds until at least one token is available again."""
+        if rate <= 0:
+            return 60
+        missing = max(0.0, 1.0 - self.tokens)
+        return max(1, int(missing / rate) + 1)
+
+
+class RateLimiter:
+    """
+    Fixed-rate token buckets keyed by caller identity.
+
+    State lives in this process only. Behind multiple workers each one enforces
+    the configured rate independently, so the effective cluster limit is
+    `workers × limit`; a shared limiter belongs at the reverse proxy. This is
+    here to stop a single client hammering one instance, not to meter a fleet.
+    """
+
+    def __init__(self, *, per_minute: int, burst: int | None = None) -> None:
+        self.per_minute = per_minute
+        self.rate = per_minute / 60.0
+        self.burst = float(burst if burst is not None else per_minute)
+        self._buckets: dict[str, Bucket] = {}
+
+    def allow(self, key: str, *, now: float | None = None) -> tuple[bool, int, int]:
+        """
+        Consume one token for `key`.
+
+        Returns (allowed, remaining, retry_after_seconds).
+        """
+        now = time.monotonic() if now is None else now
+
+        bucket = self._buckets.get(key)
+        if bucket is None:
+            if len(self._buckets) >= _PRUNE_THRESHOLD:
+                self._prune(now)
+            bucket = Bucket(tokens=self.burst, updated_at=now)
+            self._buckets[key] = bucket
+
+        allowed = bucket.take(rate=self.rate, burst=self.burst, now=now)
+        remaining = int(bucket.tokens)
+        retry_after = 0 if allowed else bucket.retry_after(rate=self.rate, now=now)
+        return allowed, remaining, retry_after
+
+    def _prune(self, now: float) -> None:
+        """Drop buckets that have refilled completely — they carry no state."""
+        full_after = self.burst / self.rate if self.rate > 0 else 0
+        stale = [
+            key
+            for key, bucket in self._buckets.items()
+            if now - bucket.updated_at > full_after
+        ]
+        for key in stale:
+            del self._buckets[key]
+        log.debug("Pruned %d idle rate-limit buckets", len(stale))
+
+    def reset(self) -> None:
+        self._buckets.clear()
+
+
+def client_key(request: Request) -> str:
+    """
+    Identify the caller.
+
+    `X-Forwarded-For` is only consulted when `trusted_proxy_hops` says a proxy
+    is in front of us; otherwise any client could set the header and hand
+    itself a fresh bucket per request.
+    """
+    hops = settings.trusted_proxy_hops
+    if hops > 0:
+        forwarded = request.headers.get("X-Forwarded-For", "")
+        chain = [part.strip() for part in forwarded.split(",") if part.strip()]
+        if chain:
+            # The right-most entries are added by our own proxies; step back
+            # past them to reach the address the outermost proxy observed.
+            index = max(0, len(chain) - hops)
+            return chain[index]
+
+    return request.client.host if request.client else "unknown"
+
+
+class RateLimitMiddleware(BaseHTTPMiddleware):
+    """Applies a per-caller request budget to the webhook and API surfaces."""
+
+    def __init__(
+        self,
+        app,
+        *,
+        webhook_limiter: RateLimiter | None = None,
+        api_limiter: RateLimiter | None = None,
+    ) -> None:
+        super().__init__(app)
+        self.webhook = webhook_limiter or RateLimiter(
+            per_minute=settings.rate_limit_webhook_per_minute,
+            burst=settings.rate_limit_burst or None,
+        )
+        self.api = api_limiter or RateLimiter(
+            per_minute=settings.rate_limit_api_per_minute,
+            burst=settings.rate_limit_burst or None,
+        )
+
+    def _limiter_for(self, path: str) -> tuple[RateLimiter | None, str]:
+        if path in EXEMPT_PATHS:
+            return None, ""
+        if path.startswith("/webhook"):
+            return self.webhook, "webhook"
+        if path.startswith("/api/"):
+            return self.api, "api"
+        return None, ""
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        if not settings.rate_limit_enabled:
+            return await call_next(request)
+
+        limiter, scope = self._limiter_for(request.url.path)
+        if limiter is None:
+            return await call_next(request)
+
+        key = f"{scope}:{client_key(request)}"
+        allowed, remaining, retry_after = limiter.allow(key)
+
+        if not allowed:
+            log.warning(
+                "Rate limit exceeded on %s by %s", request.url.path, key
+            )
+            return JSONResponse(
+                status_code=429,
+                content={
+                    "detail": "Rate limit exceeded",
+                    "retry_after": retry_after,
+                },
+                headers={
+                    "Retry-After": str(retry_after),
+                    "X-RateLimit-Limit": str(limiter.per_minute),
+                    "X-RateLimit-Remaining": "0",
+                },
+            )
+
+        response = await call_next(request)
+        response.headers["X-RateLimit-Limit"] = str(limiter.per_minute)
+        response.headers["X-RateLimit-Remaining"] = str(remaining)
+        return response

--- a/app/utils/ratelimit.py
+++ b/app/utils/ratelimit.py
@@ -145,7 +145,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
     def _limiter_for(self, path: str) -> tuple[RateLimiter | None, str]:
         if path in EXEMPT_PATHS:
             return None, ""
-        if path.startswith("/webhook"):
+        if path == "/webhook":
             return self.webhook, "webhook"
         if path.startswith("/api/"):
             return self.api, "api"

--- a/app/utils/settings.py
+++ b/app/utils/settings.py
@@ -39,7 +39,9 @@ class Settings(BaseSettings):
     # GitHub OAuth & Session Security
     github_oauth_client_id: str = ""
     github_oauth_client_secret: str = ""
-    session_secret_key: str = "dev-secret-key-32-bytes-minimum-length-change-in-prod"
+    session_secret_key: str = (
+        "dev-secret-key-32-bytes-minimum-length-change-in-prod"
+    )
     token_encryption_key: str = "dev-token-encryption-key-32b-change-in-prod="
     legacy_basic_auth_enabled: bool = True
 
@@ -48,6 +50,19 @@ class Settings(BaseSettings):
     # Stripe Billing
     stripe_secret_key: str | None = None
     stripe_webhook_secret: str | None = None
+
+    # Rate limiting (per process, per caller). The webhook budget is generous
+    # because a busy org can legitimately burst deliveries; the API budget is
+    # tighter because it is the surface a stranger can reach.
+    rate_limit_enabled: bool = True
+    rate_limit_webhook_per_minute: int = 600
+    rate_limit_api_per_minute: int = 120
+    rate_limit_burst: int = 0  # 0 = burst equals the per-minute budget
+
+    # Number of proxies in front of this app. Above 0, X-Forwarded-For is
+    # trusted for caller identity; at 0 it is ignored, because a client that
+    # can forge it can hand itself an unlimited number of buckets.
+    trusted_proxy_hops: int = 0
 
     @property
     def is_production(self) -> bool:
@@ -60,14 +75,27 @@ class Settings(BaseSettings):
                 raise ValueError("GITHUB_APP_ID must be configured in production.")
             if not self.github_private_key:
                 raise ValueError("GITHUB_PRIVATE_KEY must be configured in production.")
-            if "dev-secret-key" in self.session_secret_key or len(self.session_secret_key) < 32:
-                raise ValueError("SESSION_SECRET_KEY must be set to a secure key (min 32 chars) in production.")
-            if "dev-token-encryption-key" in self.token_encryption_key or len(self.token_encryption_key) < 32:
-                raise ValueError("TOKEN_ENCRYPTION_KEY must be set to a secure 32-byte key in production.")
+            if (
+                "dev-secret-key" in self.session_secret_key
+                or len(self.session_secret_key) < 32
+            ):
+                raise ValueError(
+                    "SESSION_SECRET_KEY must be set to a secure key "
+                    "(min 32 chars) in production."
+                )
+            if (
+                "dev-token-encryption-key" in self.token_encryption_key
+                or len(self.token_encryption_key) < 32
+            ):
+                raise ValueError(
+                    "TOKEN_ENCRYPTION_KEY must be set to a secure 32-byte key "
+                    "in production."
+                )
             if not self.github_webhook_secret:
-                raise ValueError("GITHUB_WEBHOOK_SECRET must be set in production.")
+                raise ValueError(
+                    "GITHUB_WEBHOOK_SECRET must be set in production."
+                )
         return self
 
 
 settings = Settings()
-

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -207,8 +207,18 @@ async def test_webhook_and_api_budgets_are_separate(client):
     for _ in range(2):
         await client.get("/api/v1/health")
 
-    assert (await client.get("/api/v1/health")).status_code == 429
-    assert (await client.post("/webhook")).status_code == 200
+    api_response = await client.get("/api/v1/health")
+    assert api_response.status_code == 429
+
+    for _ in range(2):
+        await client.post("/webhook")
+
+    webhook_response = await client.post("/webhook")
+
+    assert webhook_response.status_code == 429
+    assert int(webhook_response.headers["Retry-After"]) >= 1
+    assert webhook_response.headers["X-RateLimit-Remaining"] == "0"
+    assert webhook_response.json()["detail"] == "Rate limit exceeded"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -1,0 +1,235 @@
+# tests/unit/test_rate_limit.py — token-bucket rate limiting (#19)
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from starlette.applications import Starlette
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+
+from app.utils import ratelimit
+from app.utils.ratelimit import Bucket, RateLimiter, RateLimitMiddleware, client_key
+from app.utils.settings import settings
+
+# ── Bucket mechanics ──────────────────────────────────────────
+
+
+def test_first_request_is_allowed():
+    limiter = RateLimiter(per_minute=60)
+    allowed, remaining, retry_after = limiter.allow("ip", now=0.0)
+
+    assert allowed
+    assert remaining == 59
+    assert retry_after == 0
+
+
+def test_budget_is_exhausted_then_refused():
+    limiter = RateLimiter(per_minute=3)
+
+    results = [limiter.allow("ip", now=0.0)[0] for _ in range(4)]
+
+    assert results == [True, True, True, False]
+
+
+def test_refusal_reports_retry_after():
+    limiter = RateLimiter(per_minute=60)
+    for _ in range(60):
+        limiter.allow("ip", now=0.0)
+
+    allowed, _, retry_after = limiter.allow("ip", now=0.0)
+
+    assert not allowed
+    assert retry_after >= 1
+
+
+def test_tokens_refill_over_time():
+    limiter = RateLimiter(per_minute=60)  # one token per second
+    for _ in range(60):
+        limiter.allow("ip", now=0.0)
+
+    assert limiter.allow("ip", now=0.5)[0] is False
+    assert limiter.allow("ip", now=2.0)[0] is True
+
+
+def test_refill_is_capped_at_burst():
+    limiter = RateLimiter(per_minute=60, burst=10)
+    limiter.allow("ip", now=0.0)
+
+    # An hour of idling must not bank an hour's worth of tokens.
+    allowed = [limiter.allow("ip", now=3600.0)[0] for _ in range(11)]
+
+    assert allowed.count(True) == 10
+
+
+def test_callers_have_independent_budgets():
+    limiter = RateLimiter(per_minute=1)
+
+    assert limiter.allow("a", now=0.0)[0] is True
+    assert limiter.allow("b", now=0.0)[0] is True
+    assert limiter.allow("a", now=0.0)[0] is False
+
+
+def test_burst_defaults_to_the_minute_budget():
+    assert RateLimiter(per_minute=42).burst == 42
+
+
+def test_explicit_burst_overrides_default():
+    assert RateLimiter(per_minute=60, burst=5).burst == 5
+
+
+def test_bucket_retry_after_with_zero_rate():
+    bucket = Bucket(tokens=0.0, updated_at=0.0)
+    assert bucket.retry_after(rate=0, now=0.0) == 60
+
+
+def test_idle_buckets_are_pruned(monkeypatch):
+    monkeypatch.setattr(ratelimit, "_PRUNE_THRESHOLD", 5)
+    limiter = RateLimiter(per_minute=60)
+
+    for i in range(5):
+        limiter.allow(f"old-{i}", now=0.0)
+
+    limiter.allow("new", now=10_000.0)
+
+    assert "old-0" not in limiter._buckets
+    assert "new" in limiter._buckets
+
+
+def test_reset_clears_state():
+    limiter = RateLimiter(per_minute=1)
+    limiter.allow("ip", now=0.0)
+    limiter.reset()
+
+    assert limiter.allow("ip", now=0.0)[0] is True
+
+
+# ── Caller identification ─────────────────────────────────────
+
+
+class FakeRequest:
+    def __init__(self, host="1.2.3.4", forwarded=None):
+        self.client = type("C", (), {"host": host})()
+        self.headers = {"X-Forwarded-For": forwarded} if forwarded else {}
+
+
+def test_forwarded_header_ignored_without_trusted_proxies(monkeypatch):
+    monkeypatch.setattr(settings, "trusted_proxy_hops", 0)
+    assert client_key(FakeRequest(forwarded="9.9.9.9")) == "1.2.3.4"
+
+
+def test_forwarded_header_used_behind_one_proxy(monkeypatch):
+    monkeypatch.setattr(settings, "trusted_proxy_hops", 1)
+    request = FakeRequest(forwarded="203.0.113.9, 10.0.0.1")
+    assert client_key(request) == "10.0.0.1"
+
+
+def test_forwarded_chain_walked_back_by_hop_count(monkeypatch):
+    monkeypatch.setattr(settings, "trusted_proxy_hops", 2)
+    request = FakeRequest(forwarded="203.0.113.9, 10.0.0.1, 10.0.0.2")
+    assert client_key(request) == "10.0.0.1"
+
+
+def test_empty_forwarded_header_falls_back_to_peer(monkeypatch):
+    monkeypatch.setattr(settings, "trusted_proxy_hops", 1)
+    assert client_key(FakeRequest(forwarded="  ")) == "1.2.3.4"
+
+
+def test_missing_client_is_labelled_unknown(monkeypatch):
+    monkeypatch.setattr(settings, "trusted_proxy_hops", 0)
+    request = FakeRequest()
+    request.client = None
+    assert client_key(request) == "unknown"
+
+
+# ── Middleware ────────────────────────────────────────────────
+
+
+def build_app(webhook_per_minute=2, api_per_minute=2):
+    async def ok(request):
+        return JSONResponse({"ok": True})
+
+    app = Starlette(
+        routes=[
+            Route("/webhook", ok, methods=["POST"]),
+            Route("/api/v1/health", ok),
+            Route("/healthz", ok),
+            Route("/", ok),
+        ]
+    )
+    app.add_middleware(
+        RateLimitMiddleware,
+        webhook_limiter=RateLimiter(per_minute=webhook_per_minute),
+        api_limiter=RateLimiter(per_minute=api_per_minute),
+    )
+    return app
+
+
+@pytest.fixture
+def limits_on(monkeypatch):
+    monkeypatch.setattr(settings, "rate_limit_enabled", True)
+    monkeypatch.setattr(settings, "trusted_proxy_hops", 0)
+
+
+@pytest.fixture
+async def client(limits_on):
+    async with AsyncClient(
+        transport=ASGITransport(app=build_app()), base_url="http://test"
+    ) as c:
+        yield c
+
+
+@pytest.mark.asyncio
+async def test_api_requests_are_throttled(client):
+    statuses = [(await client.get("/api/v1/health")).status_code for _ in range(3)]
+    assert statuses == [200, 200, 429]
+
+
+@pytest.mark.asyncio
+async def test_throttled_response_carries_retry_after(client):
+    for _ in range(3):
+        response = await client.get("/api/v1/health")
+
+    assert response.status_code == 429
+    assert int(response.headers["Retry-After"]) >= 1
+    assert response.headers["X-RateLimit-Remaining"] == "0"
+    assert response.json()["detail"] == "Rate limit exceeded"
+
+
+@pytest.mark.asyncio
+async def test_allowed_responses_carry_budget_headers(client):
+    response = await client.get("/api/v1/health")
+
+    assert response.headers["X-RateLimit-Limit"] == "2"
+    assert response.headers["X-RateLimit-Remaining"] == "1"
+
+
+@pytest.mark.asyncio
+async def test_webhook_and_api_budgets_are_separate(client):
+    for _ in range(2):
+        await client.get("/api/v1/health")
+
+    assert (await client.get("/api/v1/health")).status_code == 429
+    assert (await client.post("/webhook")).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_healthz_is_never_throttled(client):
+    statuses = [(await client.get("/healthz")).status_code for _ in range(10)]
+    assert set(statuses) == {200}
+
+
+@pytest.mark.asyncio
+async def test_unlisted_paths_are_not_throttled(client):
+    statuses = [(await client.get("/")).status_code for _ in range(10)]
+    assert set(statuses) == {200}
+
+
+@pytest.mark.asyncio
+async def test_disabling_the_feature_removes_all_limits(monkeypatch):
+    monkeypatch.setattr(settings, "rate_limit_enabled", False)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=build_app()), base_url="http://test"
+    ) as c:
+        statuses = [(await c.get("/api/v1/health")).status_code for _ in range(5)]
+
+    assert set(statuses) == {200}


### PR DESCRIPTION
Closes #19 
feat: rate limit /webhook and /api/v1 (#19)

Both public surfaces accepted unlimited requests. `/api/v1/*` is reachable by
anyone who can route to the host and every endpoint runs a database query, so
a single client could keep the connection pool saturated indefinitely. The
webhook endpoint does signature verification and config loading on every
request before it can decide to ignore one.

Adds a token-bucket limiter as ASGI middleware, with separate budgets per
surface — 600/min for webhooks (an org can legitimately burst deliveries) and
120/min for the API — keyed per caller. Refusals return 429 with `Retry-After`
and `X-RateLimit-*` headers; allowed responses carry the remaining budget.

Details worth noting for review:

* `X-Forwarded-For` is only trusted when `TRUSTED_PROXY_HOPS > 0`. Trusting it
  unconditionally would let any client mint a fresh bucket per request by
  varying the header, which is worse than no limiter at all.
* `/healthz` is exempt so a load balancer cannot lock itself out.
* Bucket tables are pruned once past 10k entries, so requests from many source
  addresses cannot grow process memory without bound.
* State is per process. Behind N workers the effective limit is N × the
  configured rate; the docstring says so and points at the reverse proxy for
  cluster-wide metering.

Everything is configurable, and `RATE_LIMIT_ENABLED=false` turns it off.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---
**Diff vs `main`:**  5 files changed, 446 insertions(+)
Tests and `ruff check` pass on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)