### PR TITLE
docs: add SECURITY.md and sync the environment reference (#21, #15)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,13 @@ DASHBOARD_PASSWORD=
 
 # Optional: max allowed webhook delivery age, in seconds
 WEBHOOK_MAX_SKEW_SECONDS=300
+
+#  Rate limiting (per process, per caller IP)
+RATE_LIMIT_ENABLED=true
+RATE_LIMIT_WEBHOOK_PER_MINUTE=600
+RATE_LIMIT_API_PER_MINUTE=120
+RATE_LIMIT_BURST=0            # 0 = burst equals the per-minute budget
+
+# Proxies in front of this app. 0 ignores X-Forwarded-For (a client can forge
+# it); set to the number of trusted hops when running behind nginx/Cloudflare.
+TRUSTED_PROXY_HOPS=0

--- a/.env.example
+++ b/.env.example
@@ -1,23 +1,56 @@
-#  Required
+# hiero-bot-py environment reference
+#
+# Copy to `.env` and fill in. Every variable below maps to a field on
+# `Settings` in app/utils/settings.py — if you add one there, add it here too.
+# Values shown are the defaults; blank means "no default, must be set".
+
+# ── Required: GitHub App credentials ──────────────────────────
+# From your GitHub App settings page.
 GITHUB_APP_ID=
+# RSA private key. Either paste the PEM with literal \n between lines, or
+# quote a real multi-line value. RSA, PKCS#8 and EC keys are all accepted.
 GITHUB_PRIVATE_KEY=
+# Must match the webhook secret configured on the App. Generate with:
+#   openssl rand -hex 32
 GITHUB_WEBHOOK_SECRET=
 
-#  Optional 
-ANTHROPIC_API_KEY=          # only needed for ai_review.enabled = true
-DATABASE_URL=sqlite+aiosqlite:///./hiero_bot.db
-PORT=8000
-LOG_LEVEL=info
-ENVIRONMENT=development
+# ── Webhook verification ──────────────────────────────────────
+# Second, still-accepted secret. Set this to the *old* value while rotating
+# GITHUB_WEBHOOK_SECRET so in-flight deliveries keep verifying, then clear it.
+GITHUB_WEBHOOK_SECRET_OLD=
+# Reject deliveries whose Date header is further than this from now.
+WEBHOOK_MAX_SKEW_SECONDS=300
 
-#  Dashboard auth (leave blank to disable) 
+# ── AI review (optional, disabled by default) ─────────────────
+# Only read when a repo config sets workflows.pull_request.ai_review.enabled.
+# Enabling AI review sends changed file contents to the provider below.
+ANTHROPIC_API_KEY=
+# OpenAI-compatible alternative. If OPENAI_API_KEY is set it takes precedence
+# over ANTHROPIC_API_KEY. OPENAI_BASE_URL points at any compatible endpoint
+# (vLLM, LM Studio, Ollama's OpenAI shim, a gateway).
+OPENAI_API_KEY=
+OPENAI_BASE_URL=
+
+# ── Database ──────────────────────────────────────────────────
+# SQLite by default. For Postgres use an async driver, e.g.
+#   postgresql+asyncpg://user:pass@host:5432/hiero_bot
+DATABASE_URL=sqlite+aiosqlite:///./hiero_bot.db
+
+# ── Server ────────────────────────────────────────────────────
+HOST=0.0.0.0
+PORT=8000
+LOG_LEVEL=info                # debug | info | warn | error
+ENVIRONMENT=development       # development | production
+                              # production starts the scheduler and warns
+                              # about an unauthenticated dashboard
+
+# ── Dashboard and API auth ────────────────────────────────────
+# Leave BOTH blank to disable auth. Blank means the dashboard and every
+# /api/v1/* endpoint are readable by anyone who can reach the port.
 DASHBOARD_USERNAME=
 DASHBOARD_PASSWORD=
 
-# Optional: max allowed webhook delivery age, in seconds
-WEBHOOK_MAX_SKEW_SECONDS=300
-
-#  Rate limiting (per process, per caller IP)
+# ── Rate limiting (per process, per caller IP) ────────────────
 RATE_LIMIT_ENABLED=true
 RATE_LIMIT_WEBHOOK_PER_MINUTE=600
 RATE_LIMIT_API_PER_MINUTE=120

--- a/README.md
+++ b/README.md
@@ -163,17 +163,36 @@ Add `.github/hiero-bot.yml` to any repo where the app is installed. Full referen
 
 ## Environment variables
 
-| Variable | Required | Description |
-|---|---|---|
-| `GITHUB_APP_ID` | ✅ | From GitHub App settings |
-| `GITHUB_PRIVATE_KEY` | ✅ | RSA private key (use `\n` for newlines) |
-| `GITHUB_WEBHOOK_SECRET` | ✅ | Webhook secret set in App settings |
-| `ANTHROPIC_API_KEY` | AI review only | Anthropic API key |
-| `DATABASE_URL` | ❌ | Default: `sqlite+aiosqlite:///./hiero_bot.db` |
-| `PORT` | ❌ | Default: `8000` |
-| `LOG_LEVEL` | ❌ | `debug/info/warn/error` |
-| `ENVIRONMENT` | ❌ | `development` / `production` |
-| `DASHBOARD_USERNAME` / `DASHBOARD_PASSWORD` | ❌ | Reserved for dashboard access control — **defined but not yet enforced; tracked in the roadmap below** |
+Full annotated reference: [`.env.example`](.env.example).
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `GITHUB_APP_ID` | ✅ | — | From GitHub App settings |
+| `GITHUB_PRIVATE_KEY` | ✅ | — | RSA/PKCS#8/EC private key (use `\n` for newlines) |
+| `GITHUB_WEBHOOK_SECRET` | ✅ | — | Webhook secret set in App settings |
+| `GITHUB_WEBHOOK_SECRET_OLD` | ❌ | unset | Second accepted secret, for zero-downtime rotation |
+| `WEBHOOK_MAX_SKEW_SECONDS` | ❌ | `300` | Reject deliveries whose `Date` is further off than this |
+| `ANTHROPIC_API_KEY` | AI review only | unset | Anthropic API key |
+| `OPENAI_API_KEY` | AI review only | unset | OpenAI-compatible key; takes precedence over Anthropic |
+| `OPENAI_BASE_URL` | ❌ | unset | Point at any OpenAI-compatible endpoint (vLLM, Ollama, a gateway) |
+| `DATABASE_URL` | ❌ | `sqlite+aiosqlite:///./hiero_bot.db` | Use an async driver for Postgres (`postgresql+asyncpg://…`) |
+| `HOST` | ❌ | `0.0.0.0` | Bind address |
+| `PORT` | ❌ | `8000` | Bind port |
+| `LOG_LEVEL` | ❌ | `info` | `debug` / `info` / `warn` / `error` |
+| `ENVIRONMENT` | ❌ | `development` | `production` starts the scheduler and warns on unauthenticated dashboards |
+| `DASHBOARD_USERNAME` / `DASHBOARD_PASSWORD` | ❌ | unset | HTTP Basic auth for the dashboard and `/api/v1/*`. **Leave both blank and those surfaces are unauthenticated.** |
+| `RATE_LIMIT_ENABLED` | ❌ | `true` | Per-caller token-bucket limiting on `/webhook` and `/api/v1/*` |
+| `RATE_LIMIT_WEBHOOK_PER_MINUTE` | ❌ | `600` | Webhook budget per caller, per process |
+| `RATE_LIMIT_API_PER_MINUTE` | ❌ | `120` | API budget per caller, per process |
+| `RATE_LIMIT_BURST` | ❌ | `0` | `0` = burst equals the per-minute budget |
+| `TRUSTED_PROXY_HOPS` | ❌ | `0` | Proxies in front of the app. `0` ignores `X-Forwarded-For` — clients can forge it |
+
+## Security
+
+Reporting a vulnerability, the threat model behind the webhook and config
+handling, and a hardening checklist for self-hosters are all in
+[SECURITY.md](SECURITY.md). Please report security issues privately rather than
+in a public issue.
 
 ## Ecosystem & standing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,173 @@
+# Security Policy
+
+`hiero-bot-py` is a self-hosted GitHub App. It holds an installation token that
+can comment, label, assign, and close issues in every repository the app is
+installed on, and it stores a history of contributor activity in a database you
+run. Both of those are worth protecting, so please read this before deploying it
+somewhere it matters.
+
+## Reporting a vulnerability
+
+**Do not open a public issue for a security problem.**
+
+Report privately through GitHub's [security advisory
+form](https://github.com/AnthropicBots/hiero-bot-py/security/advisories/new).
+If that is unavailable to you, open a regular issue containing only the words
+"security report — please contact me" and a maintainer will arrange a private
+channel. Do not include details in that issue.
+
+Please include, as far as you can:
+
+- what the vulnerability lets an attacker do,
+- the version or commit you tested,
+- reproduction steps or a proof of concept,
+- whether you believe it is being exploited.
+
+What to expect:
+
+| Stage | Target |
+|---|---|
+| Acknowledgement of your report | 3 working days |
+| Initial assessment and severity | 10 working days |
+| Fix or documented mitigation for High/Critical | 30 days |
+| Public advisory | After a fix ships, or 90 days, whichever is first |
+
+This is a small, unfunded project maintained alongside other work. These are
+honest targets, not a contractual SLA. If a deadline slips you will be told why
+rather than left waiting.
+
+Reporters are credited in the advisory unless they ask not to be. There is no
+bug bounty.
+
+## Supported versions
+
+Security fixes land on `main` and in the most recent tagged release. Older tags
+are not patched — self-hosters are expected to track `main` or the latest tag.
+
+## Scope
+
+**In scope**
+
+- Webhook signature bypass, replay, or forgery.
+- Anything that makes the bot act on a repository with no `.github/hiero-bot.yml`.
+- Privilege confusion in slash commands (a non-committer causing a committer-only action).
+- Leaking the installation token, webhook secret, private key, or AI API key into logs, comments, or API responses.
+- SQL injection, SSRF, path traversal, or unsafe deserialization anywhere in the request path.
+- Denial of service reachable by an unauthenticated caller.
+- Anything that lets a repository's config file cause execution outside that repository's context.
+
+**Out of scope**
+
+- Findings that require the attacker to already hold the app's private key, webhook secret, or database credentials.
+- Missing hardening on a deployment that ignores the checklist below — for example an internet-exposed dashboard with `DASHBOARD_PASSWORD` unset.
+- Rate limits being per-process rather than cluster-wide. This is documented behaviour; see `app/utils/ratelimit.py`.
+- Vulnerabilities in GitHub itself, or in a dependency with no exploitable path through this code. Report those upstream.
+- Output quality of the optional AI review. A wrong review is a bug, not a vulnerability.
+
+## Threat model
+
+The bot's exposed surfaces are the webhook endpoint, the REST API, the
+dashboard, and the per-repository config file. Each is treated as attacker
+controlled.
+
+### Webhook deliveries
+
+Anyone can POST to `/webhook`. The endpoint therefore assumes the body is
+hostile until proven otherwise:
+
+- **Signature.** `X-Hub-Signature-256` is recomputed with HMAC-SHA256 over the
+  raw body and compared with `hmac.compare_digest`, so comparison time does not
+  leak how much of the digest matched. A request with no signature header is
+  rejected outright.
+- **Secret rotation.** Two secrets can be live at once
+  (`GITHUB_WEBHOOK_SECRET` and `GITHUB_WEBHOOK_SECRET_OLD`), so a secret can be
+  rotated in GitHub without dropping in-flight deliveries. Remove the old value
+  once rotation is complete — a retired secret that stays configured is an
+  extra key that still works.
+- **Replay.** `X-GitHub-Delivery` IDs are remembered for 10 minutes, so a
+  captured delivery cannot be resubmitted to repeat an action.
+- **Clock skew.** Deliveries whose `Date` header is further than
+  `WEBHOOK_MAX_SKEW_SECONDS` from now are refused. This is defence in depth
+  behind the signature and replay checks, not a control in its own right.
+- **Rate limiting.** A per-caller token bucket bounds how much work an
+  unauthenticated client can force the process to do.
+
+### Repository configuration
+
+`.github/hiero-bot.yml` is written by whoever can push to the repository, which
+is not necessarily someone you trust.
+
+- The bot is **silent by default**: with no config file, nothing runs. This is
+  the single most important property in the design — installing the app on an
+  organisation does not opt every repository into automated comments.
+- YAML is parsed with `yaml.safe_load`, so no object construction or arbitrary
+  tags. Documents are size-limited and must have a mapping at the top level.
+- Every value is validated against a pydantic schema before use. A config that
+  fails validation disables the bot for that repository and is logged; it never
+  half-applies.
+- Config values name teams, labels, and file paths within the same repository.
+  They are never used to build a request to another host.
+
+### Tokens and secrets
+
+- The GitHub App private key is read from the environment and used only to mint
+  short-lived installation tokens. Tokens are cached in memory with their real
+  expiry and never written to disk or to the database.
+- Audit records store *what the bot did and why*, never credentials.
+- Log lines are written with `%s` parameters rather than interpolated strings,
+  and no code path logs a token, secret, or API key. If you find one, that is a
+  reportable vulnerability.
+- The optional AI review sends changed file contents and diffs to the
+  configured model provider. It is **off by default**. Turning it on means
+  accepting that your source is transmitted to that provider — do not enable it
+  on a private repository without checking that provider's data policy.
+
+### Dashboard and REST API
+
+- Both sit behind HTTP Basic auth when `DASHBOARD_USERNAME` and
+  `DASHBOARD_PASSWORD` are set, compared with `hmac.compare_digest`.
+- **If those are unset, the dashboard and the whole API are unauthenticated.**
+  Startup logs a warning in production, but nothing refuses to boot. Anyone who
+  reaches the port can read your contributor metrics and audit history.
+- The API is read-only. It exposes no endpoint that mutates state or reaches
+  GitHub.
+- All queries go through SQLAlchemy with bound parameters; no SQL is built by
+  string concatenation.
+
+## Hardening checklist for self-hosters
+
+- [ ] Set `ENVIRONMENT=production`.
+- [ ] Set `DASHBOARD_USERNAME` and `DASHBOARD_PASSWORD`, or keep the port off the public internet entirely.
+- [ ] Terminate TLS in front of the app. Basic auth over plain HTTP hands over the password.
+- [ ] Set `GITHUB_WEBHOOK_SECRET` to a high-entropy value (`openssl rand -hex 32`) and make it match the App settings.
+- [ ] Set `TRUSTED_PROXY_HOPS` to the number of proxies actually in front of the app — leave it at `0` if there are none.
+- [ ] Give the GitHub App the narrowest permission set your enabled workflows need.
+- [ ] Run the container as a non-root user and mount the filesystem read-only apart from the database path.
+- [ ] Put the database somewhere backed up; the audit trail is the record of everything the bot has done.
+- [ ] Keep `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` unset unless AI review is deliberately enabled.
+- [ ] Rotate the webhook secret and the App private key on a schedule you actually keep.
+
+## Dependency and supply chain policy
+
+- Runtime dependencies are pinned in `requirements.txt`.
+- CI runs `pip-audit` on every push and fails the build on any finding with a
+  High or Critical CVSS score. `pip-audit` has no severity flag of its own, so
+  `.github/scripts/check_audit_severity.py` does the filtering against each
+  finding's score.
+- To reproduce locally:
+
+  ```bash
+  pip install pip-audit
+  pip-audit -r requirements.txt -f json -o audit-report.json
+  python .github/scripts/check_audit_severity.py audit-report.json
+  ```
+
+- Dependency updates that fix a known vulnerability are merged ahead of feature
+  work.
+
+## Data handling
+
+See [PRIVACY.md](PRIVACY.md) for what is stored and for how long. In short: the
+bot stores public GitHub activity metadata in a database you control, and no
+data leaves your infrastructure except calls to the GitHub API — plus, if you
+explicitly enable AI review, calls to your chosen model provider.

--- a/app/main.py
+++ b/app/main.py
@@ -18,6 +18,7 @@ from app.github.webhooks import WebhookRouter
 from app.scheduler.jobs import BotScheduler
 from app.utils.auth import _auth_configured, require_dashboard_auth
 from app.utils.logger import get_logger
+from app.utils.ratelimit import RateLimitMiddleware
 from app.utils.settings import settings
 
 log = get_logger("main")
@@ -66,6 +67,8 @@ app = FastAPI(
     version="2.0.0",
     lifespan=lifespan,
 )
+
+app.add_middleware(RateLimitMiddleware)
 
 app.include_router(api_router, dependencies=[Depends(require_dashboard_auth)])
 

--- a/app/utils/ratelimit.py
+++ b/app/utils/ratelimit.py
@@ -1,0 +1,185 @@
+# app/utils/ratelimit.py — Token-bucket rate limiting for public endpoints
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+from app.utils.logger import get_logger
+from app.utils.settings import settings
+
+log = get_logger("utils.ratelimit")
+
+# Paths that must never be throttled: a load balancer polling health should not
+# be able to lock itself out, and it carries no cost worth protecting.
+EXEMPT_PATHS = frozenset({"/healthz"})
+
+# Buckets are pruned once the table grows past this, so a spray of requests from
+# many source addresses cannot grow the process's memory without limit.
+_PRUNE_THRESHOLD = 10_000
+
+
+@dataclass
+class Bucket:
+    """A token bucket: `tokens` refill at `rate` per second, capped at `burst`."""
+
+    tokens: float
+    updated_at: float
+
+    def take(self, *, rate: float, burst: float, now: float) -> bool:
+        elapsed = now - self.updated_at
+        self.tokens = min(burst, self.tokens + elapsed * rate)
+        self.updated_at = now
+
+        if self.tokens < 1.0:
+            return False
+
+        self.tokens -= 1.0
+        return True
+
+    def retry_after(self, *, rate: float, now: float) -> int:
+        """Whole seconds until at least one token is available again."""
+        if rate <= 0:
+            return 60
+        missing = max(0.0, 1.0 - self.tokens)
+        return max(1, int(missing / rate) + 1)
+
+
+class RateLimiter:
+    """
+    Fixed-rate token buckets keyed by caller identity.
+
+    State lives in this process only. Behind multiple workers each one enforces
+    the configured rate independently, so the effective cluster limit is
+    `workers × limit`; a shared limiter belongs at the reverse proxy. This is
+    here to stop a single client hammering one instance, not to meter a fleet.
+    """
+
+    def __init__(self, *, per_minute: int, burst: int | None = None) -> None:
+        self.per_minute = per_minute
+        self.rate = per_minute / 60.0
+        self.burst = float(burst if burst is not None else per_minute)
+        self._buckets: dict[str, Bucket] = {}
+
+    def allow(self, key: str, *, now: float | None = None) -> tuple[bool, int, int]:
+        """
+        Consume one token for `key`.
+
+        Returns (allowed, remaining, retry_after_seconds).
+        """
+        now = time.monotonic() if now is None else now
+
+        bucket = self._buckets.get(key)
+        if bucket is None:
+            if len(self._buckets) >= _PRUNE_THRESHOLD:
+                self._prune(now)
+            bucket = Bucket(tokens=self.burst, updated_at=now)
+            self._buckets[key] = bucket
+
+        allowed = bucket.take(rate=self.rate, burst=self.burst, now=now)
+        remaining = int(bucket.tokens)
+        retry_after = 0 if allowed else bucket.retry_after(rate=self.rate, now=now)
+        return allowed, remaining, retry_after
+
+    def _prune(self, now: float) -> None:
+        """Drop buckets that have refilled completely — they carry no state."""
+        full_after = self.burst / self.rate if self.rate > 0 else 0
+        stale = [
+            key
+            for key, bucket in self._buckets.items()
+            if now - bucket.updated_at > full_after
+        ]
+        for key in stale:
+            del self._buckets[key]
+        log.debug("Pruned %d idle rate-limit buckets", len(stale))
+
+    def reset(self) -> None:
+        self._buckets.clear()
+
+
+def client_key(request: Request) -> str:
+    """
+    Identify the caller.
+
+    `X-Forwarded-For` is only consulted when `trusted_proxy_hops` says a proxy
+    is in front of us; otherwise any client could set the header and hand
+    itself a fresh bucket per request.
+    """
+    hops = settings.trusted_proxy_hops
+    if hops > 0:
+        forwarded = request.headers.get("X-Forwarded-For", "")
+        chain = [part.strip() for part in forwarded.split(",") if part.strip()]
+        if chain:
+            # The right-most entries are added by our own proxies; step back
+            # past them to reach the address the outermost proxy observed.
+            index = max(0, len(chain) - hops)
+            return chain[index]
+
+    return request.client.host if request.client else "unknown"
+
+
+class RateLimitMiddleware(BaseHTTPMiddleware):
+    """Applies a per-caller request budget to the webhook and API surfaces."""
+
+    def __init__(
+        self,
+        app,
+        *,
+        webhook_limiter: RateLimiter | None = None,
+        api_limiter: RateLimiter | None = None,
+    ) -> None:
+        super().__init__(app)
+        self.webhook = webhook_limiter or RateLimiter(
+            per_minute=settings.rate_limit_webhook_per_minute,
+            burst=settings.rate_limit_burst or None,
+        )
+        self.api = api_limiter or RateLimiter(
+            per_minute=settings.rate_limit_api_per_minute,
+            burst=settings.rate_limit_burst or None,
+        )
+
+    def _limiter_for(self, path: str) -> tuple[RateLimiter | None, str]:
+        if path in EXEMPT_PATHS:
+            return None, ""
+        if path.startswith("/webhook"):
+            return self.webhook, "webhook"
+        if path.startswith("/api/"):
+            return self.api, "api"
+        return None, ""
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        if not settings.rate_limit_enabled:
+            return await call_next(request)
+
+        limiter, scope = self._limiter_for(request.url.path)
+        if limiter is None:
+            return await call_next(request)
+
+        key = f"{scope}:{client_key(request)}"
+        allowed, remaining, retry_after = limiter.allow(key)
+
+        if not allowed:
+            log.warning(
+                "Rate limit exceeded on %s by %s", request.url.path, key
+            )
+            return JSONResponse(
+                status_code=429,
+                content={
+                    "detail": "Rate limit exceeded",
+                    "retry_after": retry_after,
+                },
+                headers={
+                    "Retry-After": str(retry_after),
+                    "X-RateLimit-Limit": str(limiter.per_minute),
+                    "X-RateLimit-Remaining": "0",
+                },
+            )
+
+        response = await call_next(request)
+        response.headers["X-RateLimit-Limit"] = str(limiter.per_minute)
+        response.headers["X-RateLimit-Remaining"] = str(remaining)
+        return response

--- a/app/utils/settings.py
+++ b/app/utils/settings.py
@@ -35,6 +35,19 @@ class Settings(BaseSettings):
     dashboard_username: str | None = None
     dashboard_password: str | None = None
 
+    # Rate limiting (per process, per caller). The webhook budget is generous
+    # because a busy org can legitimately burst deliveries; the API budget is
+    # tighter because it is the surface a stranger can reach.
+    rate_limit_enabled: bool = True
+    rate_limit_webhook_per_minute: int = 600
+    rate_limit_api_per_minute: int = 120
+    rate_limit_burst: int = 0  # 0 = burst equals the per-minute budget
+
+    # Number of proxies in front of this app. Above 0, X-Forwarded-For is
+    # trusted for caller identity; at 0 it is ignored, because a client that
+    # can forge it can hand itself an unlimited number of buckets.
+    trusted_proxy_hops: int = 0
+
     @property
     def is_production(self) -> bool:
         return self.environment == "production"

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -1,0 +1,235 @@
+# tests/unit/test_rate_limit.py — token-bucket rate limiting (#19)
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from starlette.applications import Starlette
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+
+from app.utils import ratelimit
+from app.utils.ratelimit import Bucket, RateLimiter, RateLimitMiddleware, client_key
+from app.utils.settings import settings
+
+# ── Bucket mechanics ──────────────────────────────────────────
+
+
+def test_first_request_is_allowed():
+    limiter = RateLimiter(per_minute=60)
+    allowed, remaining, retry_after = limiter.allow("ip", now=0.0)
+
+    assert allowed
+    assert remaining == 59
+    assert retry_after == 0
+
+
+def test_budget_is_exhausted_then_refused():
+    limiter = RateLimiter(per_minute=3)
+
+    results = [limiter.allow("ip", now=0.0)[0] for _ in range(4)]
+
+    assert results == [True, True, True, False]
+
+
+def test_refusal_reports_retry_after():
+    limiter = RateLimiter(per_minute=60)
+    for _ in range(60):
+        limiter.allow("ip", now=0.0)
+
+    allowed, _, retry_after = limiter.allow("ip", now=0.0)
+
+    assert not allowed
+    assert retry_after >= 1
+
+
+def test_tokens_refill_over_time():
+    limiter = RateLimiter(per_minute=60)  # one token per second
+    for _ in range(60):
+        limiter.allow("ip", now=0.0)
+
+    assert limiter.allow("ip", now=0.5)[0] is False
+    assert limiter.allow("ip", now=2.0)[0] is True
+
+
+def test_refill_is_capped_at_burst():
+    limiter = RateLimiter(per_minute=60, burst=10)
+    limiter.allow("ip", now=0.0)
+
+    # An hour of idling must not bank an hour's worth of tokens.
+    allowed = [limiter.allow("ip", now=3600.0)[0] for _ in range(11)]
+
+    assert allowed.count(True) == 10
+
+
+def test_callers_have_independent_budgets():
+    limiter = RateLimiter(per_minute=1)
+
+    assert limiter.allow("a", now=0.0)[0] is True
+    assert limiter.allow("b", now=0.0)[0] is True
+    assert limiter.allow("a", now=0.0)[0] is False
+
+
+def test_burst_defaults_to_the_minute_budget():
+    assert RateLimiter(per_minute=42).burst == 42
+
+
+def test_explicit_burst_overrides_default():
+    assert RateLimiter(per_minute=60, burst=5).burst == 5
+
+
+def test_bucket_retry_after_with_zero_rate():
+    bucket = Bucket(tokens=0.0, updated_at=0.0)
+    assert bucket.retry_after(rate=0, now=0.0) == 60
+
+
+def test_idle_buckets_are_pruned(monkeypatch):
+    monkeypatch.setattr(ratelimit, "_PRUNE_THRESHOLD", 5)
+    limiter = RateLimiter(per_minute=60)
+
+    for i in range(5):
+        limiter.allow(f"old-{i}", now=0.0)
+
+    limiter.allow("new", now=10_000.0)
+
+    assert "old-0" not in limiter._buckets
+    assert "new" in limiter._buckets
+
+
+def test_reset_clears_state():
+    limiter = RateLimiter(per_minute=1)
+    limiter.allow("ip", now=0.0)
+    limiter.reset()
+
+    assert limiter.allow("ip", now=0.0)[0] is True
+
+
+# ── Caller identification ─────────────────────────────────────
+
+
+class FakeRequest:
+    def __init__(self, host="1.2.3.4", forwarded=None):
+        self.client = type("C", (), {"host": host})()
+        self.headers = {"X-Forwarded-For": forwarded} if forwarded else {}
+
+
+def test_forwarded_header_ignored_without_trusted_proxies(monkeypatch):
+    monkeypatch.setattr(settings, "trusted_proxy_hops", 0)
+    assert client_key(FakeRequest(forwarded="9.9.9.9")) == "1.2.3.4"
+
+
+def test_forwarded_header_used_behind_one_proxy(monkeypatch):
+    monkeypatch.setattr(settings, "trusted_proxy_hops", 1)
+    request = FakeRequest(forwarded="203.0.113.9, 10.0.0.1")
+    assert client_key(request) == "10.0.0.1"
+
+
+def test_forwarded_chain_walked_back_by_hop_count(monkeypatch):
+    monkeypatch.setattr(settings, "trusted_proxy_hops", 2)
+    request = FakeRequest(forwarded="203.0.113.9, 10.0.0.1, 10.0.0.2")
+    assert client_key(request) == "10.0.0.1"
+
+
+def test_empty_forwarded_header_falls_back_to_peer(monkeypatch):
+    monkeypatch.setattr(settings, "trusted_proxy_hops", 1)
+    assert client_key(FakeRequest(forwarded="  ")) == "1.2.3.4"
+
+
+def test_missing_client_is_labelled_unknown(monkeypatch):
+    monkeypatch.setattr(settings, "trusted_proxy_hops", 0)
+    request = FakeRequest()
+    request.client = None
+    assert client_key(request) == "unknown"
+
+
+# ── Middleware ────────────────────────────────────────────────
+
+
+def build_app(webhook_per_minute=2, api_per_minute=2):
+    async def ok(request):
+        return JSONResponse({"ok": True})
+
+    app = Starlette(
+        routes=[
+            Route("/webhook", ok, methods=["POST"]),
+            Route("/api/v1/health", ok),
+            Route("/healthz", ok),
+            Route("/", ok),
+        ]
+    )
+    app.add_middleware(
+        RateLimitMiddleware,
+        webhook_limiter=RateLimiter(per_minute=webhook_per_minute),
+        api_limiter=RateLimiter(per_minute=api_per_minute),
+    )
+    return app
+
+
+@pytest.fixture
+def limits_on(monkeypatch):
+    monkeypatch.setattr(settings, "rate_limit_enabled", True)
+    monkeypatch.setattr(settings, "trusted_proxy_hops", 0)
+
+
+@pytest.fixture
+async def client(limits_on):
+    async with AsyncClient(
+        transport=ASGITransport(app=build_app()), base_url="http://test"
+    ) as c:
+        yield c
+
+
+@pytest.mark.asyncio
+async def test_api_requests_are_throttled(client):
+    statuses = [(await client.get("/api/v1/health")).status_code for _ in range(3)]
+    assert statuses == [200, 200, 429]
+
+
+@pytest.mark.asyncio
+async def test_throttled_response_carries_retry_after(client):
+    for _ in range(3):
+        response = await client.get("/api/v1/health")
+
+    assert response.status_code == 429
+    assert int(response.headers["Retry-After"]) >= 1
+    assert response.headers["X-RateLimit-Remaining"] == "0"
+    assert response.json()["detail"] == "Rate limit exceeded"
+
+
+@pytest.mark.asyncio
+async def test_allowed_responses_carry_budget_headers(client):
+    response = await client.get("/api/v1/health")
+
+    assert response.headers["X-RateLimit-Limit"] == "2"
+    assert response.headers["X-RateLimit-Remaining"] == "1"
+
+
+@pytest.mark.asyncio
+async def test_webhook_and_api_budgets_are_separate(client):
+    for _ in range(2):
+        await client.get("/api/v1/health")
+
+    assert (await client.get("/api/v1/health")).status_code == 429
+    assert (await client.post("/webhook")).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_healthz_is_never_throttled(client):
+    statuses = [(await client.get("/healthz")).status_code for _ in range(10)]
+    assert set(statuses) == {200}
+
+
+@pytest.mark.asyncio
+async def test_unlisted_paths_are_not_throttled(client):
+    statuses = [(await client.get("/")).status_code for _ in range(10)]
+    assert set(statuses) == {200}
+
+
+@pytest.mark.asyncio
+async def test_disabling_the_feature_removes_all_limits(monkeypatch):
+    monkeypatch.setattr(settings, "rate_limit_enabled", False)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=build_app()), base_url="http://test"
+    ) as c:
+        statuses = [(await c.get("/api/v1/health")).status_code for _ in range(5)]
+
+    assert set(statuses) == {200}


### PR DESCRIPTION
docs: add SECURITY.md and sync the environment reference (#21, #15)

#21 — the project had no security policy at all, so there was no private
channel for reporting and no statement of what the bot is trusted with.
SECURITY.md covers private reporting with realistic response targets, scope
(explicitly including what is out of scope), the threat model for each exposed
surface — webhook deliveries, repository config, tokens, the dashboard/API — a
hardening checklist for self-hosters, and the existing pip-audit supply-chain
policy.

Two things it states plainly because they surprise people: with
DASHBOARD_USERNAME/PASSWORD unset the dashboard and the whole read API are
unauthenticated, and enabling AI review transmits changed file contents to the
configured provider.

#15 — .env.example had drifted from Settings. It was missing
GITHUB_WEBHOOK_SECRET_OLD, OPENAI_API_KEY, OPENAI_BASE_URL, HOST and the rate
limit settings; the README table was missing the same and still described
dashboard auth as "defined but not yet enforced", which stopped being true
when app/utils/auth.py landed. Both now match settings.py field for field,
with defaults and the precedence rule between the two AI keys.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---
> **Stacked on #56.** GitHub requires a cross-fork PR's base to exist upstream, so this targets `main` and therefore also shows #56's commit. Review the second commit (`docs: add SECURITY.md and sync the environment reference`) only, and merge #56 first — the env reference here documents the rate-limit settings #56 adds.

**Own diff vs #56's branch:** 3 files changed, 246 insertions(+), 21 deletions(-)
Tests and `ruff check` pass on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)