### PR TITLE
fix: fail closed on onboarding history lookup errors

### DIFF
--- a/app/workflows/onboarding.py
+++ b/app/workflows/onboarding.py
@@ -240,10 +240,10 @@ class OnboardingWorkflow:
                 },
             )
         except Exception as exc:
-            # Unknown history: fall back to the association signal, which already
-            # told us they are not an established contributor.
+            # If contributor history cannot be verified, do not claim that this
+            # is a first-time contributor.
             log.warning("Could not read issue history for @%s: %s", login, exc)
-            return True
+            return False
 
         others = [
             item

--- a/tests/unit/test_onboarding.py
+++ b/tests/unit/test_onboarding.py
@@ -99,11 +99,11 @@ async def test_welcomes_everyone_when_first_time_only_disabled(mock_gh, ctx):
 
 
 @pytest.mark.asyncio
-async def test_welcomes_when_issue_history_lookup_fails(mock_gh, ctx):
+async def test_skips_when_issue_history_lookup_fails(mock_gh, ctx):
     mock_gh.get = AsyncMock(side_effect=RuntimeError("api down"))
     wf = OnboardingWorkflow(mock_gh)
     await wf.handle_new_contributor(ctx, make_payload())
-    mock_gh.post_comment.assert_awaited_once()
+    mock_gh.post_comment.assert_not_awaited()
 
 
 # ── Bot detection (#42: check_human_contributors) ─────────────
@@ -275,6 +275,20 @@ async def test_cla_gate_fails_closed_when_file_missing(mock_gh, ctx):
     ctx["config"].workflows.onboarding.require_signed_cla = True
     mock_gh.get = AsyncMock(return_value={"number": 1, "assignees": []})
     mock_gh.get_file_content = AsyncMock(return_value=None)
+
+    wf = OnboardingWorkflow(mock_gh)
+    await wf.handle_self_assign(ctx, make_payload())
+
+    mock_gh.add_assignees.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_cla_gate_fails_closed_when_file_lookup_fails(mock_gh, ctx):
+    ctx["config"].workflows.onboarding.require_signed_cla = True
+    mock_gh.get = AsyncMock(return_value={"number": 1, "assignees": []})
+    mock_gh.get_file_content = AsyncMock(
+        side_effect=RuntimeError("GitHub API down")
+    )
 
     wf = OnboardingWorkflow(mock_gh)
     await wf.handle_self_assign(ctx, make_payload())


### PR DESCRIPTION
Follow-up to #53.

This fixes the remaining review concern in #53:

- `_has_no_prior_issues()` no longer treats a GitHub history lookup failure as proof of a first-time contributor.
- The regression test now asserts that no first-time welcome is posted when history cannot be verified.
- Added coverage ensuring a CLA signature-file lookup failure still fails closed and blocks assignment.

Validation completed locally:

- `pytest -q` — all tests passed
- `ruff check .` — passed
- `git diff --check` — passed

Related PR: #53
Closes #42 
Closes #40 