### PR TITLE
docs: document reviewer assignment workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Nobody has a self-hosted, open-source system that treats maintainer-ops as a who
 | **Onboarding** | Detects first-time contributors, posts a welcome checklist, validates account age / public-repo count before `/assign`, round-robins mentor assignment |
 | **PR quality gates** | DCO sign-off, GPG signature, test-file presence, linked-issue requirement, branch naming pattern, max file count — auto-labelled `quality: ✅` / `❌` |
 | **PR health scoring** | Every PR scored 0–100 across 6 configurable, weighted signals (tests, linked issue, description, DCO, approvals, diff size) |
-| **Reviewer recommendation** | Suggests reviewers based on recent file-history overlap, logged with a reason and confidence score |
+| **Reviewer assignment** | Automatically requests reviewers on newly opened, non-draft PRs using a repo-local `.github/reviewers.yml` availability file and configurable `round-robin` or `random` selection |
+| **Reviewer recommendation** | Suggests reviewers based on recent file-history overlap, logged with a reason and confidence score; posts a comment-only recommendation rather than requesting a review |
 | **AI-assisted review** *(optional)* | Structured review (summary, verdict, line comments, severity) via the Anthropic SDK — disabled by default, never required |
 | **Contributor progression** | Tracks merged PRs, reviews given, months active; computes eligibility for `junior-committer → committer → maintainer`; celebrates merge milestones (1st, 5th, 10th, 25th, 50th) |
 | **Issue management** | Daily stale scan (cron), auto-unassign on inactivity, label-based escalation to specific teams |

--- a/templates/hiero-bot.yml
+++ b/templates/hiero-bot.yml
@@ -74,6 +74,47 @@ workflows:
     stale_pr_days: 30
     auto_close_stale: false
 
+  #  Reviewer Assignment
+  #
+  # Automatically requests reviewers on newly opened, non-draft PRs.
+  # Unlike pull_request.reviewer_recommendation, this makes a real
+  # GitHub review request.
+  reviewer_assignment:
+    enabled: false
+
+    # Repository-local YAML file containing reviewer availability.
+    availability_file: ".github/reviewers.yml"
+
+    # Maximum number of reviewers to request.
+    reviewers_count: 1
+
+    # Reviewer selection strategy:
+    # round-robin → select reviewers based on PR number
+    # random      → randomly select eligible reviewers
+    strategy: round-robin
+
+    # Do not request a review from the PR author.
+    exclude_pr_author: true
+
+    # If no reviewers are currently marked available, fall back
+    # to all reviewers listed in the availability file.
+    fallback_to_all_if_none_available: true
+
+    # Whether to post a comment mentioning the selected reviewers.
+    # off     → only create the GitHub review request
+    # mention → create the review request and mention reviewers in a comment
+    notify_comment: off
+
+    # Create .github/reviewers.yml with:
+    #
+    # reviewers:
+    #   - login: reviewer1
+    #     available: true
+    #   - login: reviewer2
+    #     available: false
+    #
+    # See .github/reviewers.yml in this repository for a working example.
+
   #  PR Health Scoring
   pr_health:
     enabled: true


### PR DESCRIPTION
## Summary

- document the `reviewer_assignment` workflow in the full configuration template
- document the `.github/reviewers.yml` availability file format
- distinguish formal reviewer assignment from comment-only reviewer recommendation in the README

Closes #66