### PR TITLE
feat: add configurable concurrent self-assignment limit

### DIFF
--- a/app/config/schema.py
+++ b/app/config/schema.py
@@ -45,6 +45,9 @@ class OnboardingConfig(BaseModel):
 
     minimum_account_age_days: int = Field(default=0, ge=0)
     minimum_public_contributions: int = Field(default=0, ge=0)
+    # Maximum number of open issues a contributor can hold in this repository.
+    # Set to null to disable the limit.
+    max_concurrent_assignments: int | None = Field(default=None, ge=1)
     auto_assign_mentor: bool = False
     mentor_assignment_strategy: MentorStrategy = "round-robin"
     welcome_message: str | None = None

--- a/app/github/client.py
+++ b/app/github/client.py
@@ -282,6 +282,29 @@ class GitHubClient:
         )
         return items
 
+    async def count_assigned_open_issues(
+        self,
+        owner: str,
+        repo: str,
+        login: str,
+        installation_id: int,
+        *,
+        max_pages: int = MAX_PAGES,
+    ) -> int:
+        """Count open issues assigned to a user, excluding pull requests."""
+        items = await self.paginate(
+            f"/repos/{owner}/{repo}/issues",
+            installation_id,
+            params={
+                "assignee": login,
+                "state": "open",
+            },
+            per_page=100,
+            max_pages=max_pages,
+        )
+
+        return sum(1 for item in items if "pull_request" not in item)
+
     async def _paginate_app(
         self,
         path: str,

--- a/app/workflows/onboarding.py
+++ b/app/workflows/onboarding.py
@@ -17,6 +17,7 @@ from app.utils.logger import get_logger
 log = get_logger("workflow.onboarding")
 
 _assign_locks: dict[tuple[str, str, int], asyncio.Lock] = {}
+_contributor_assign_locks: dict[tuple[str, str, str], asyncio.Lock] = {}
 
 
 def _get_assign_lock(owner: str, repo: str, issue_number: int) -> asyncio.Lock:
@@ -24,6 +25,17 @@ def _get_assign_lock(owner: str, repo: str, issue_number: int) -> asyncio.Lock:
     if key not in _assign_locks:
         _assign_locks[key] = asyncio.Lock()
     return _assign_locks[key]
+
+
+def _get_contributor_assign_lock(
+    owner: str,
+    repo: str,
+    login: str,
+) -> asyncio.Lock:
+    key = (owner, repo, login.lower())
+    if key not in _contributor_assign_locks:
+        _contributor_assign_locks[key] = asyncio.Lock()
+    return _contributor_assign_locks[key]
 
 
 # Bot detection. Substring matching is deliberately avoided — "bot" appears in
@@ -154,12 +166,30 @@ class OnboardingWorkflow:
                 await self._gh.post_comment(owner, repo, issue_number, msg, inst)
                 return
 
-            ok, reason = await self._check_eligibility(ctx, login)
-            if not ok:
-                await self._gh.post_comment(owner, repo, issue_number, reason, inst)
-                return
+            if cfg.max_concurrent_assignments is not None:
+                async with _get_contributor_assign_lock(owner, repo, login):
+                    ok, reason = await self._check_eligibility(ctx, login)
+                    if not ok:
+                        await self._gh.post_comment(
+                            owner, repo, issue_number, reason, inst
+                        )
+                        return
 
-            await self._gh.add_assignees(owner, repo, issue_number, [login], inst)
+                    await self._gh.add_assignees(
+                        owner, repo, issue_number, [login], inst
+                    )
+            else:
+                ok, reason = await self._check_eligibility(ctx, login)
+                if not ok:
+                    await self._gh.post_comment(
+                        owner, repo, issue_number, reason, inst
+                    )
+                    return
+
+                await self._gh.add_assignees(
+                    owner, repo, issue_number, [login], inst
+                )
+
             await self._gh.post_comment(
                 owner,
                 repo,
@@ -256,6 +286,43 @@ class OnboardingWorkflow:
 
     async def _check_eligibility(self, ctx: dict, login: str) -> tuple[bool, str]:
         cfg = ctx["config"].workflows.onboarding
+        if cfg.max_concurrent_assignments is not None:
+            owner = ctx["owner"]
+            repo = ctx["repo"]
+            installation_id = ctx["installation_id"]
+
+            try:
+                current = await self._gh.count_assigned_open_issues(
+                    owner,
+                    repo,
+                    login,
+                    installation_id,
+                )
+            except Exception as exc:
+                log.error(
+                    "Could not check concurrent assignments for @%s in %s/%s: %s",
+                    login,
+                    owner,
+                    repo,
+                    exc,
+                )
+                return (
+                    False,
+                    (
+                        f"⚠️ @{login} We couldn't verify your current issue "
+                        "assignments. Please try again later."
+                    ),
+                )
+
+            if current >= cfg.max_concurrent_assignments:
+                return (
+                    False,
+                    (
+                        f"⚠️ @{login} You already have {current} open issue(s) "
+                        "assigned in this repository. Please finish one before "
+                        "taking another issue."
+                    ),
+                )
 
         # Account-quality checks fail open: a GitHub hiccup should not stop a
         # legitimate contributor from picking up an issue.

--- a/templates/hiero-bot.yml
+++ b/templates/hiero-bot.yml
@@ -40,6 +40,10 @@ workflows:
 
     minimum_account_age_days: 0       # 0 = no minimum
     minimum_public_contributions: 0   # 0 = no minimum
+    # Maximum number of open issues a contributor can have assigned
+    # simultaneously in this repository.
+    # Set to null to disable the limit.
+    max_concurrent_assignments: 3
     auto_assign_mentor: false
     mentor_assignment_strategy: round-robin  # round-robin | least-busy | expertise-match
     welcome_message: |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,7 @@ def mock_gh():
     gh.update_comment = AsyncMock()
     gh.add_label = AsyncMock()
     gh.add_assignees = AsyncMock()
+    gh.count_assigned_open_issues = AsyncMock(return_value=0)
     gh.remove_assignees = AsyncMock()
     gh.close_issue = AsyncMock()
     gh.list_issues = AsyncMock(return_value=[])

--- a/tests/unit/test_config_schema.py
+++ b/tests/unit/test_config_schema.py
@@ -22,9 +22,42 @@ def test_defaults_applied():
     cfg = RepoConfig.model_validate(MINIMAL)
     assert cfg.workflows.onboarding.enabled is True
     assert cfg.workflows.onboarding.minimum_account_age_days == 0
+    assert cfg.workflows.onboarding.max_concurrent_assignments is None
     assert cfg.workflows.pull_request.stale_pr_days == 30
     assert cfg.workflows.issue_management.stale_issue_days == 60
     assert cfg.workflows.pr_health.enabled is True
+
+
+def test_max_concurrent_assignments_validation():
+    unlimited = RepoConfig.model_validate({
+        "repo": "hiero/x",
+        "workflows": {
+            "onboarding": {
+                "max_concurrent_assignments": None,
+            }
+        },
+    })
+    assert unlimited.workflows.onboarding.max_concurrent_assignments is None
+
+    limited = RepoConfig.model_validate({
+        "repo": "hiero/x",
+        "workflows": {
+            "onboarding": {
+                "max_concurrent_assignments": 5,
+            }
+        },
+    })
+    assert limited.workflows.onboarding.max_concurrent_assignments == 5
+
+    with pytest.raises(ValidationError):
+        RepoConfig.model_validate({
+            "repo": "hiero/x",
+            "workflows": {
+                "onboarding": {
+                    "max_concurrent_assignments": 0,
+                }
+            },
+        })
 
 
 def test_ai_review_max_comments_capped():

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -256,6 +256,163 @@ async def test_paginate_respects_max_pages_cap():
 
 
 @pytest.mark.asyncio
+async def test_count_assigned_open_issues_single_page():
+    client = GitHubClient()
+
+    items = [
+        {"number": 1},
+        {"number": 2},
+        {"number": 3},
+    ]
+
+    with patch.object(
+        client,
+        "get",
+        new=AsyncMock(return_value=items),
+    ) as mock_get:
+        count = await client.count_assigned_open_issues(
+            "hiero",
+            "sdk-js",
+            "alice",
+            123,
+        )
+
+    assert count == 3
+    mock_get.assert_awaited_once_with(
+        "/repos/hiero/sdk-js/issues",
+        123,
+        params={
+            "assignee": "alice",
+            "state": "open",
+            "per_page": 100,
+            "page": 1,
+        },
+    )
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_count_assigned_open_issues_paginates():
+    client = GitHubClient()
+
+    first_page = [{"number": i} for i in range(100)]
+    second_page = [{"number": 100 + i} for i in range(25)]
+
+    with patch.object(
+        client,
+        "get",
+        new=AsyncMock(side_effect=[first_page, second_page]),
+    ) as mock_get:
+        count = await client.count_assigned_open_issues(
+            "hiero",
+            "sdk-js",
+            "alice",
+            123,
+        )
+
+    assert count == 125
+    assert mock_get.await_count == 2
+
+    mock_get.assert_any_await(
+        "/repos/hiero/sdk-js/issues",
+        123,
+        params={
+            "assignee": "alice",
+            "state": "open",
+            "per_page": 100,
+            "page": 1,
+        },
+    )
+    mock_get.assert_any_await(
+        "/repos/hiero/sdk-js/issues",
+        123,
+        params={
+            "assignee": "alice",
+            "state": "open",
+            "per_page": 100,
+            "page": 2,
+        },
+    )
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_count_assigned_open_issues_excludes_pull_requests():
+    client = GitHubClient()
+
+    items = [
+        {"number": 1},
+        {"number": 2, "pull_request": {"url": "https://api.github.com/pr/2"}},
+        {"number": 3},
+        {"number": 4, "pull_request": {"url": "https://api.github.com/pr/4"}},
+    ]
+
+    with patch.object(
+        client,
+        "get",
+        new=AsyncMock(return_value=items),
+    ):
+        count = await client.count_assigned_open_issues(
+            "hiero",
+            "sdk-js",
+            "alice",
+            123,
+        )
+
+    assert count == 2
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_count_assigned_open_issues_respects_max_pages():
+    client = GitHubClient()
+
+    first_page = [{"number": i} for i in range(100)]
+    second_page = [{"number": 100 + i} for i in range(100)]
+    third_page = [{"number": 200 + i} for i in range(100)]
+    fourth_page = [{"number": 300 + i} for i in range(100)]
+
+    with patch.object(
+        client,
+        "get",
+        new=AsyncMock(
+            side_effect=[
+                first_page,
+                second_page,
+                third_page,
+                fourth_page,
+            ]
+        ),
+    ) as mock_get:
+        count = await client.count_assigned_open_issues(
+            "hiero",
+            "sdk-js",
+            "alice",
+            123,
+            max_pages=3,
+        )
+
+    assert count == 300
+    assert mock_get.await_count == 3
+
+    mock_get.assert_any_await(
+        "/repos/hiero/sdk-js/issues",
+        123,
+        params={
+            "assignee": "alice",
+            "state": "open",
+            "per_page": 100,
+            "page": 3,
+        },
+    )
+
+    await client.close()
+
+
+@pytest.mark.asyncio
 async def test_paginate_preserves_caller_params():
     client = GitHubClient()
 

--- a/tests/unit/test_installation_webhooks.py
+++ b/tests/unit/test_installation_webhooks.py
@@ -110,6 +110,8 @@ async def test_config_change_invalidates_cache_before_loading(db):
     }
 
     request = MagicMock()
+    request.body = AsyncMock(return_value=b"")
+    router._verify_signature = MagicMock()
     request.headers = {
         "X-GitHub-Event": "push",
     }
@@ -147,6 +149,8 @@ async def test_invalid_config_is_acknowledged_without_retrying(db):
     }
 
     request = MagicMock()
+    request.body = AsyncMock(return_value=b"")
+    router._verify_signature = MagicMock()
     request.headers = {
         "X-GitHub-Event": "pull_request",
     }

--- a/tests/unit/test_onboarding.py
+++ b/tests/unit/test_onboarding.py
@@ -1,5 +1,6 @@
 # tests/unit/test_onboarding.py
 
+import asyncio
 import base64
 import json
 from datetime import datetime, timedelta, timezone
@@ -190,6 +191,114 @@ async def test_self_assign_success(mock_gh, ctx):
     await wf.handle_self_assign(ctx, make_payload(assignees=[]))
     mock_gh.add_assignees.assert_awaited_once()
     assert mock_gh.add_assignees.call_args[0][3] == ["alice"]
+
+
+@pytest.mark.asyncio
+async def test_self_assign_blocked_at_assignment_limit(mock_gh, ctx):
+    ctx["config"].workflows.onboarding.max_concurrent_assignments = 3
+    mock_gh.get = AsyncMock(return_value={"number": 1, "assignees": []})
+    mock_gh.count_assigned_open_issues = AsyncMock(return_value=3)
+
+    wf = OnboardingWorkflow(mock_gh)
+    await wf.handle_self_assign(ctx, make_payload(assignees=[]))
+
+    mock_gh.add_assignees.assert_not_awaited()
+    mock_gh.count_assigned_open_issues.assert_awaited_once_with(
+        "hiero",
+        "sdk-js",
+        "alice",
+        42,
+    )
+    body = mock_gh.post_comment.call_args[0][3]
+    assert "already have 3 open issue(s)" in body
+
+
+@pytest.mark.asyncio
+async def test_self_assign_allowed_under_assignment_limit(mock_gh, ctx):
+    ctx["config"].workflows.onboarding.max_concurrent_assignments = 3
+    mock_gh.get = AsyncMock(return_value={"number": 1, "assignees": []})
+    mock_gh.count_assigned_open_issues = AsyncMock(return_value=2)
+
+    wf = OnboardingWorkflow(mock_gh)
+    await wf.handle_self_assign(ctx, make_payload(assignees=[]))
+
+    mock_gh.count_assigned_open_issues.assert_awaited_once_with(
+        "hiero",
+        "sdk-js",
+        "alice",
+        42,
+    )
+    mock_gh.add_assignees.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_self_assign_skips_assignment_limit_when_unset(mock_gh, ctx):
+    ctx["config"].workflows.onboarding.max_concurrent_assignments = None
+    mock_gh.get = AsyncMock(return_value={"number": 1, "assignees": []})
+
+    wf = OnboardingWorkflow(mock_gh)
+    await wf.handle_self_assign(ctx, make_payload(assignees=[]))
+
+    mock_gh.count_assigned_open_issues.assert_not_awaited()
+    mock_gh.add_assignees.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_self_assign_fails_closed_when_assignment_count_lookup_fails(
+    mock_gh, ctx
+):
+    ctx["config"].workflows.onboarding.max_concurrent_assignments = 3
+    mock_gh.get = AsyncMock(return_value={"number": 1, "assignees": []})
+    mock_gh.count_assigned_open_issues = AsyncMock(
+        side_effect=RuntimeError("GitHub API down")
+    )
+
+    wf = OnboardingWorkflow(mock_gh)
+    await wf.handle_self_assign(ctx, make_payload(assignees=[]))
+
+    mock_gh.add_assignees.assert_not_awaited()
+    body = mock_gh.post_comment.call_args[0][3]
+    assert "couldn't verify your current issue assignments" in body
+
+
+@pytest.mark.asyncio
+async def test_self_assign_concurrent_requests_respect_assignment_limit(mock_gh, ctx):
+    ctx["config"].workflows.onboarding.max_concurrent_assignments = 3
+
+    mock_gh.get = AsyncMock(
+        side_effect=[
+            {"number": 1, "assignees": []},
+            {"number": 2, "assignees": []},
+        ]
+    )
+
+    assignment_count = 2
+
+    async def count_assigned_open_issues(*args):
+        return assignment_count
+
+    mock_gh.count_assigned_open_issues = AsyncMock(
+        side_effect=count_assigned_open_issues
+    )
+
+    async def add_assignee(*args):
+        nonlocal assignment_count
+        assignment_count += 1
+
+    mock_gh.add_assignees = AsyncMock(side_effect=add_assignee)
+
+    wf = OnboardingWorkflow(mock_gh)
+
+    payload_one = make_payload(issue_number=1, assignees=[])
+    payload_two = make_payload(issue_number=2, assignees=[])
+
+    await asyncio.gather(
+        wf.handle_self_assign(ctx, payload_one),
+        wf.handle_self_assign(ctx, payload_two),
+    )
+
+    assert mock_gh.add_assignees.await_count == 1
+    assert mock_gh.count_assigned_open_issues.await_count == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

`/assign` currently has no limit on how many open issues a contributor can hold in a repository at the same time.

A contributor can repeatedly self-assign issues and end up holding an unbounded number of open issues, which can crowd out other contributors and make issue ownership harder to track.

## What changed

- Added a repository-configurable `max_concurrent_assignments` setting to `OnboardingConfig`.
- The setting defaults to `null` so existing repositories remain unlimited unless they opt into the limit.
- Repositories can configure their own limit in `.github/hiero-bot.yml`, for example:
  ```yaml
  max_concurrent_assignments: 3

Closes #67 