### PR TITLE
test: cover SQLite dialect guard on PRAGMA connect listener

### DIFF
--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -1,0 +1,24 @@
+# tests/unit/test_database.py
+
+from unittest.mock import MagicMock, patch
+
+from app.db.database import _set_sqlite_pragma, engine
+
+
+def test_pragma_runs_on_sqlite():
+    dbapi_connection = MagicMock()
+    with patch.object(engine.dialect, "name", "sqlite"):
+        _set_sqlite_pragma(dbapi_connection, None)
+
+    cursor = dbapi_connection.cursor.return_value
+    cursor.execute.assert_any_call("PRAGMA journal_mode=WAL")
+    cursor.execute.assert_any_call("PRAGMA busy_timeout=30000")
+    cursor.close.assert_called_once()
+
+
+def test_pragma_skipped_on_postgres():
+    dbapi_connection = MagicMock()
+    with patch.object(engine.dialect, "name", "postgresql"):
+        _set_sqlite_pragma(dbapi_connection, None)
+
+    dbapi_connection.cursor.assert_not_called()


### PR DESCRIPTION
## Summary

Fixes #63.

The dialect guard described in #63 (`if engine.dialect.name == "sqlite":` before running the `PRAGMA` statements in `app/db/database.py`) was already fixed upstream — it landed incidentally as part of an unrelated commit (multi-tenant/alembic work) rather than through a PR that closed the issue, which is why #63 was still open.

What was still missing per the issue's acceptance criteria was test coverage for that guard. This PR adds it:

- `_set_sqlite_pragma` runs the `PRAGMA journal_mode=WAL` / `PRAGMA busy_timeout=30000` calls when `engine.dialect.name == "sqlite"`
- it's a no-op (no cursor/execute calls) when the dialect is `postgresql`

## Test plan

- [x] `python -m pytest tests/unit/test_database.py -v` — 2 new tests pass
- [x] `python -m pytest tests/unit/` — full unit suite (242 tests) passes