### PR TITLE
perf: stop re-querying authorized owners in verify_owner_access

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -113,7 +113,7 @@ async def get_audit_log(
     db: AsyncSession = Depends(get_db),
 ):
     if owner:
-        await verify_owner_access(owner, user, db)
+        verify_owner_access(owner, user, allowed_owners)
     elif not allowed_owners:
         return []
 
@@ -161,7 +161,7 @@ async def get_pr_health(
     db: AsyncSession = Depends(get_db),
 ):
     if owner:
-        await verify_owner_access(owner, user, db)
+        verify_owner_access(owner, user, allowed_owners)
     elif not allowed_owners:
         return []
 
@@ -189,9 +189,10 @@ async def get_pr_health_stats(
     owner: str = Query(...),
     repo: str = Query(...),
     user: User = Depends(get_current_user),
+    allowed_owners: set[str] = Depends(get_authorized_owners),
     db: AsyncSession = Depends(get_db),
 ):
-    await verify_owner_access(owner, user, db)
+    verify_owner_access(owner, user, allowed_owners)
     result = await db.execute(
         select(
             func.avg(PRHealthScore.score).label("avg_score"),
@@ -225,7 +226,7 @@ async def get_contributors(
     db: AsyncSession = Depends(get_db),
 ):
     if owner:
-        await verify_owner_access(owner, user, db)
+        verify_owner_access(owner, user, allowed_owners)
     elif not allowed_owners:
         return []
 
@@ -253,9 +254,10 @@ async def get_repo_stats(
     owner: str = Query(...),
     repo: str = Query(...),
     user: User = Depends(get_current_user),
+    allowed_owners: set[str] = Depends(get_authorized_owners),
     db: AsyncSession = Depends(get_db),
 ):
-    await verify_owner_access(owner, user, db)
+    verify_owner_access(owner, user, allowed_owners)
 
     async def count(model, **filters):
         q = select(func.count()).select_from(model)
@@ -296,7 +298,7 @@ async def get_stale_log(
     db: AsyncSession = Depends(get_db),
 ):
     if owner:
-        await verify_owner_access(owner, user, db)
+        verify_owner_access(owner, user, allowed_owners)
     elif not allowed_owners:
         return []
 

--- a/app/utils/access.py
+++ b/app/utils/access.py
@@ -22,12 +22,11 @@ async def get_authorized_owners(
     return {acc["org_login"] for acc in accounts if acc.get("org_login")}
 
 
-async def verify_owner_access(
+def verify_owner_access(
     owner: str,
     user: User,
-    db: AsyncSession,
+    allowed_owners: set[str],
 ) -> None:
-    allowed_owners = await get_authorized_owners(user, db)
     if owner not in allowed_owners:
         log.warning("User @%s attempted unauthorized access to org '%s'", user.github_login, owner)
         raise HTTPException(

--- a/tests/unit/test_cross_tenant_isolation.py
+++ b/tests/unit/test_cross_tenant_isolation.py
@@ -11,7 +11,7 @@ from app.auth.session import (
     unsign_session_id,
 )
 from app.db.models import Account, AccountUser, User
-from app.utils.access import verify_owner_access
+from app.utils.access import get_authorized_owners, verify_owner_access
 
 
 @pytest.mark.asyncio
@@ -62,11 +62,13 @@ async def test_cross_tenant_access_denial(db):
     db.add(AccountUser(account_id=acc_b.id, user_id=user_b.id, authorized=True))
     await db.commit()
 
+    allowed_owners = await get_authorized_owners(user_a, db)
+
     # User A should pass for org_a
-    await verify_owner_access("org_a", user_a, db)
+    verify_owner_access("org_a", user_a, allowed_owners)
 
     # User A must get 403 when trying to access org_b
     with pytest.raises(HTTPException) as exc_info:
-        await verify_owner_access("org_b", user_a, db)
+        verify_owner_access("org_b", user_a, allowed_owners)
     assert exc_info.value.status_code == 403
     assert "Access denied to organization 'org_b'" in exc_info.value.detail


### PR DESCRIPTION
Fixes #76

verify_owner_access re-fetched allowed owners from the DB even when the caller already had them from Depends(get_authorized_owners), doubling the tenant-lookup query on every owner-filtered request. Make it a plain sync membership check and inject allowed_owners everywhere via the same dependency.