### PR TITLE
Security: use generated Fernet keys for token encryption

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,7 +20,9 @@ ENVIRONMENT=development
 GITHUB_OAUTH_CLIENT_ID=
 GITHUB_OAUTH_CLIENT_SECRET=
 SESSION_SECRET_KEY=dev-secret-key-32-bytes-minimum-length-change-in-prod
-TOKEN_ENCRYPTION_KEY=dev-token-encryption-key-32b-change-in-prod=
+# Generate with:
+# python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+TOKEN_ENCRYPTION_KEY=
 
 # Non-production defaults. Override via env (comma-separated or JSON list) in production.
 CORS_ORIGINS=["http://localhost:3000","http://localhost:5173"]

--- a/app/auth/session.py
+++ b/app/auth/session.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-import base64
-
-# Key derivation helper for Fernet token encryption
 import secrets
 from datetime import datetime, timedelta, timezone
 
@@ -21,11 +18,7 @@ SESSION_EXPIRE_SECONDS = 86400 * 7  # 7 days
 
 
 def _get_fernet() -> Fernet:
-    key = settings.token_encryption_key.encode("utf-8")
-    if len(key) < 32:
-        key = key.ljust(32, b"0")
-    encoded_key = base64.urlsafe_b64encode(key[:32])
-    return Fernet(encoded_key)
+    return Fernet(settings.token_encryption_key.encode("ascii"))
 
 
 def encrypt_token(plain_token: str) -> str:

--- a/app/utils/settings.py
+++ b/app/utils/settings.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from cryptography.fernet import Fernet
 from pydantic import model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -78,14 +79,20 @@ class Settings(BaseSettings):
                     "SESSION_SECRET_KEY must be set to a secure key "
                     "(min 32 chars) in production."
                 )
-            if (
-                "dev-token-encryption-key" in self.token_encryption_key
-                or len(self.token_encryption_key) < 32
-            ):
+
+            if "dev-token-encryption-key" in self.token_encryption_key:
                 raise ValueError(
-                    "TOKEN_ENCRYPTION_KEY must be set to a secure 32-byte key "
+                    "TOKEN_ENCRYPTION_KEY must be set to a generated Fernet key "
                     "in production."
                 )
+
+            try:
+                Fernet(self.token_encryption_key.encode("ascii"))
+            except (UnicodeEncodeError, ValueError):
+                raise ValueError(
+                    "TOKEN_ENCRYPTION_KEY must be a valid Fernet key in production."
+                ) from None
+
             if not self.github_webhook_secret:
                 raise ValueError(
                     "GITHUB_WEBHOOK_SECRET must be set in production."

--- a/tests/unit/test_production_readiness.py
+++ b/tests/unit/test_production_readiness.py
@@ -1,4 +1,5 @@
 import pytest
+from cryptography.fernet import Fernet
 
 from app.auth.sync import _SYNC_CACHE, _prune_expired_cache
 from app.utils.settings import Settings
@@ -26,6 +27,36 @@ def test_production_settings_validation():
             github_webhook_secret="sec",
         )
     assert "SESSION_SECRET_KEY" in str(exc_info.value)
+
+
+def test_production_settings_accepts_valid_fernet_key():
+    settings = Settings(
+        _env_file=None,
+        environment="production",
+        github_app_id="123456",
+        github_private_key="test-private-key",
+        session_secret_key="session-secret-key-that-is-long-enough",
+        token_encryption_key=Fernet.generate_key().decode(),
+        github_webhook_secret="sec",
+    )
+
+    assert settings.is_production is True
+
+
+def test_production_settings_rejects_arbitrary_32_character_key():
+    with pytest.raises(
+        ValueError,
+        match="TOKEN_ENCRYPTION_KEY must be a valid Fernet key in production.",
+    ):
+        Settings(
+            _env_file=None,
+            environment="production",
+            github_app_id="123456",
+            github_private_key="test-private-key",
+            session_secret_key="session-secret-key-that-is-long-enough",
+            token_encryption_key="a" * 32,
+            github_webhook_secret="sec",
+        )
 
 
 def test_sync_cache_pruning():


### PR DESCRIPTION
## Summary

Replace the ad-hoc `TOKEN_ENCRYPTION_KEY` padding/truncation scheme with direct Fernet keys and validate the configured key format in production.

## Changes

* Remove manual padding, truncation, and Base64 transformation from `_get_fernet()`.
* Require `TOKEN_ENCRYPTION_KEY` to be a valid generated Fernet key in production.
* Update `.env.example` with instructions for generating a Fernet key.
* Add regression tests for accepting valid Fernet keys and rejecting arbitrary 32-character strings.

## Validation

* `pytest tests\unit\test_production_readiness.py -q`
* `pytest tests\unit\test_session_auth.py -q`
* `pytest -q`
* `ruff check app tests`

Closes #74