### PR TITLE
fix: evict stale in-memory locks in onboarding workflow

### DIFF
--- a/app/workflows/onboarding.py
+++ b/app/workflows/onboarding.py
@@ -6,6 +6,7 @@ import asyncio
 import base64
 import json
 from collections import OrderedDict
+from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 
 from sqlalchemy import select
@@ -18,31 +19,57 @@ from app.utils.logger import get_logger
 log = get_logger("workflow.onboarding")
 
 
+class _TrackedLock:
+    """Track active users of an underlying asyncio lock."""
+
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        self._users = 0
+
+    @asynccontextmanager
+    async def acquire(self):
+        self._users += 1
+        try:
+            await self._lock.acquire()
+            try:
+                yield
+            finally:
+                self._lock.release()
+        finally:
+            self._users -= 1
+
+    @property
+    def users(self) -> int:
+        return self._users
+
+
 class BoundedLockRegistry:
-    """Bounded registry for asyncio.Lock instances with LRU eviction."""
+    """Bounded registry for asyncio locks with LRU eviction."""
 
     def __init__(self, max_capacity: int = 1024) -> None:
-        self._max_capacity = max_capacity
-        self._locks: OrderedDict[tuple, asyncio.Lock] = OrderedDict()
+        if max_capacity < 1:
+            raise ValueError("max_capacity must be at least 1")
 
-    def get(self, key: tuple) -> asyncio.Lock:
+        self._max_capacity = max_capacity
+        self._locks: OrderedDict[tuple, _TrackedLock] = OrderedDict()
+
+    def get(self, key: tuple) -> _TrackedLock:
         if key in self._locks:
             self._locks.move_to_end(key)
             return self._locks[key]
 
-        # Evict the oldest unheld lock when the registry reaches capacity.
         if len(self._locks) >= self._max_capacity:
             for existing_key in list(self._locks.keys()):
                 lock = self._locks[existing_key]
-                if not lock.locked():
+                if lock.users == 0:
                     del self._locks[existing_key]
                     break
             else:
                 raise RuntimeError(
-                    "Lock registry is at capacity and all locks are currently held"
+                    "Lock registry is at capacity and all locks are currently in use"
                 )
 
-        lock = asyncio.Lock()
+        lock = _TrackedLock()
         self._locks[key] = lock
         return lock
 
@@ -51,7 +78,11 @@ _assign_locks = BoundedLockRegistry(max_capacity=2048)
 _contributor_assign_locks = BoundedLockRegistry(max_capacity=2048)
 
 
-def _get_assign_lock(owner: str, repo: str, issue_number: int) -> asyncio.Lock:
+def _get_assign_lock(
+    owner: str,
+    repo: str,
+    issue_number: int,
+) -> _TrackedLock:
     return _assign_locks.get((owner, repo, issue_number))
 
 
@@ -59,7 +90,7 @@ def _get_contributor_assign_lock(
     owner: str,
     repo: str,
     login: str,
-) -> asyncio.Lock:
+) -> _TrackedLock:
     return _contributor_assign_locks.get((owner, repo, login.lower()))
 
 
@@ -177,7 +208,7 @@ class OnboardingWorkflow:
         owner, repo, inst = ctx["owner"], ctx["repo"], ctx["installation_id"]
         db = ctx["db"]
 
-        async with _get_assign_lock(owner, repo, issue_number):
+        async with _get_assign_lock(owner, repo, issue_number).acquire():
             live_issue = await self._gh.get(
                 f"/repos/{owner}/{repo}/issues/{issue_number}", inst
             )
@@ -192,7 +223,7 @@ class OnboardingWorkflow:
                 return
 
             if cfg.max_concurrent_assignments is not None:
-                async with _get_contributor_assign_lock(owner, repo, login):
+                async with _get_contributor_assign_lock(owner, repo, login).acquire():
                     ok, reason = await self._check_eligibility(ctx, login)
                     if not ok:
                         await self._gh.post_comment(

--- a/app/workflows/onboarding.py
+++ b/app/workflows/onboarding.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+from collections import OrderedDict
 from datetime import datetime, timezone
 
 from sqlalchemy import select
@@ -16,15 +17,42 @@ from app.utils.logger import get_logger
 
 log = get_logger("workflow.onboarding")
 
-_assign_locks: dict[tuple[str, str, int], asyncio.Lock] = {}
-_contributor_assign_locks: dict[tuple[str, str, str], asyncio.Lock] = {}
+
+class BoundedLockRegistry:
+    """Bounded registry for asyncio.Lock instances with LRU eviction."""
+
+    def __init__(self, max_capacity: int = 1024) -> None:
+        self._max_capacity = max_capacity
+        self._locks: OrderedDict[tuple, asyncio.Lock] = OrderedDict()
+
+    def get(self, key: tuple) -> asyncio.Lock:
+        if key in self._locks:
+            self._locks.move_to_end(key)
+            return self._locks[key]
+
+        # Evict the oldest unheld lock when the registry reaches capacity.
+        if len(self._locks) >= self._max_capacity:
+            for existing_key in list(self._locks.keys()):
+                lock = self._locks[existing_key]
+                if not lock.locked():
+                    del self._locks[existing_key]
+                    break
+            else:
+                raise RuntimeError(
+                    "Lock registry is at capacity and all locks are currently held"
+                )
+
+        lock = asyncio.Lock()
+        self._locks[key] = lock
+        return lock
+
+
+_assign_locks = BoundedLockRegistry(max_capacity=2048)
+_contributor_assign_locks = BoundedLockRegistry(max_capacity=2048)
 
 
 def _get_assign_lock(owner: str, repo: str, issue_number: int) -> asyncio.Lock:
-    key = (owner, repo, issue_number)
-    if key not in _assign_locks:
-        _assign_locks[key] = asyncio.Lock()
-    return _assign_locks[key]
+    return _assign_locks.get((owner, repo, issue_number))
 
 
 def _get_contributor_assign_lock(
@@ -32,10 +60,7 @@ def _get_contributor_assign_lock(
     repo: str,
     login: str,
 ) -> asyncio.Lock:
-    key = (owner, repo, login.lower())
-    if key not in _contributor_assign_locks:
-        _contributor_assign_locks[key] = asyncio.Lock()
-    return _contributor_assign_locks[key]
+    return _contributor_assign_locks.get((owner, repo, login.lower()))
 
 
 # Bot detection. Substring matching is deliberately avoided — "bot" appears in
@@ -319,7 +344,7 @@ class OnboardingWorkflow:
                     False,
                     (
                         f"⚠️ @{login} You already have {current} open issue(s) "
-                        "assigned in this repository. Please finish one before "
+                        f"assigned in this repository. Please finish one before "
                         "taking another issue."
                     ),
                 )

--- a/tests/unit/test_onboarding.py
+++ b/tests/unit/test_onboarding.py
@@ -395,7 +395,7 @@ def test_bounded_lock_registry_refreshes_lru_order():
     registry = BoundedLockRegistry(max_capacity=2)
 
     first = registry.get(("hiero", "sdk-js", 1))
-    second = registry.get(("hiero", "sdk-js", 2))
+    registry.get(("hiero", "sdk-js", 2))
 
     assert registry.get(("hiero", "sdk-js", 1)) is first
 

--- a/tests/unit/test_onboarding.py
+++ b/tests/unit/test_onboarding.py
@@ -9,7 +9,12 @@ from unittest.mock import AsyncMock
 import pytest
 
 from app.utils import audit
-from app.workflows.onboarding import OnboardingWorkflow, looks_like_bot
+from app.workflows.onboarding import (
+    BoundedLockRegistry,
+    OnboardingWorkflow,
+    _get_contributor_assign_lock,
+    looks_like_bot,
+)
 
 
 def make_payload(
@@ -201,7 +206,6 @@ async def test_self_assign_blocked_at_assignment_limit(mock_gh, ctx):
 
     wf = OnboardingWorkflow(mock_gh)
     await wf.handle_self_assign(ctx, make_payload(assignees=[]))
-
     mock_gh.add_assignees.assert_not_awaited()
     mock_gh.count_assigned_open_issues.assert_awaited_once_with(
         "hiero",
@@ -221,7 +225,6 @@ async def test_self_assign_allowed_under_assignment_limit(mock_gh, ctx):
 
     wf = OnboardingWorkflow(mock_gh)
     await wf.handle_self_assign(ctx, make_payload(assignees=[]))
-
     mock_gh.count_assigned_open_issues.assert_awaited_once_with(
         "hiero",
         "sdk-js",
@@ -235,7 +238,6 @@ async def test_self_assign_allowed_under_assignment_limit(mock_gh, ctx):
 async def test_self_assign_skips_assignment_limit_when_unset(mock_gh, ctx):
     ctx["config"].workflows.onboarding.max_concurrent_assignments = None
     mock_gh.get = AsyncMock(return_value={"number": 1, "assignees": []})
-
     wf = OnboardingWorkflow(mock_gh)
     await wf.handle_self_assign(ctx, make_payload(assignees=[]))
 
@@ -255,7 +257,6 @@ async def test_self_assign_fails_closed_when_assignment_count_lookup_fails(
 
     wf = OnboardingWorkflow(mock_gh)
     await wf.handle_self_assign(ctx, make_payload(assignees=[]))
-
     mock_gh.add_assignees.assert_not_awaited()
     body = mock_gh.post_comment.call_args[0][3]
     assert "couldn't verify your current issue assignments" in body
@@ -271,7 +272,6 @@ async def test_self_assign_concurrent_requests_respect_assignment_limit(mock_gh,
             {"number": 2, "assignees": []},
         ]
     )
-
     assignment_count = 2
 
     async def count_assigned_open_issues(*args):
@@ -288,7 +288,6 @@ async def test_self_assign_concurrent_requests_respect_assignment_limit(mock_gh,
     mock_gh.add_assignees = AsyncMock(side_effect=add_assignee)
 
     wf = OnboardingWorkflow(mock_gh)
-
     payload_one = make_payload(issue_number=1, assignees=[])
     payload_two = make_payload(issue_number=2, assignees=[])
 
@@ -303,7 +302,9 @@ async def test_self_assign_concurrent_requests_respect_assignment_limit(mock_gh,
 
 @pytest.mark.asyncio
 async def test_self_assign_already_assigned(mock_gh, ctx):
-    mock_gh.get = AsyncMock(return_value={"number": 1, "assignees": [{"login": "alice"}]})
+    mock_gh.get = AsyncMock(
+        return_value={"number": 1, "assignees": [{"login": "alice"}]}
+    )
     wf = OnboardingWorkflow(mock_gh)
     await wf.handle_self_assign(ctx, make_payload(assignees=[{"login": "alice"}]))
     mock_gh.add_assignees.assert_not_awaited()
@@ -318,7 +319,6 @@ async def test_self_assign_blocked_by_min_age(mock_gh, ctx):
     recent_date = (datetime.now(timezone.utc) - timedelta(days=10)).strftime(
         "%Y-%m-%dT%H:%M:%SZ"
     )
-
     mock_gh.get = AsyncMock(return_value={"number": 1, "assignees": []})
     mock_gh.get_user = AsyncMock(
         return_value={
@@ -343,6 +343,86 @@ async def test_account_check_failure_does_not_block_assignment(mock_gh, ctx):
     mock_gh.add_assignees.assert_awaited_once()
 
 
+# ── Bounded lock registry (#101) ──────────────────────────────
+
+
+def test_bounded_lock_registry_reuses_lock_for_same_key():
+    registry = BoundedLockRegistry(max_capacity=4)
+
+    first = registry.get(("hiero", "sdk-js", 1))
+    second = registry.get(("hiero", "sdk-js", 1))
+
+    assert first is second
+    assert len(registry._locks) == 1
+
+
+def test_bounded_lock_registry_evicts_oldest_unlocked_lock():
+    registry = BoundedLockRegistry(max_capacity=2)
+
+    first = registry.get(("hiero", "sdk-js", 1))
+    second = registry.get(("hiero", "sdk-js", 2))
+
+    third = registry.get(("hiero", "sdk-js", 3))
+
+    assert len(registry._locks) == 2
+    assert ("hiero", "sdk-js", 1) not in registry._locks
+    assert registry.get(("hiero", "sdk-js", 2)) is second
+    assert registry.get(("hiero", "sdk-js", 3)) is third
+    assert registry.get(("hiero", "sdk-js", 1)) is not first
+
+
+@pytest.mark.asyncio
+async def test_bounded_lock_registry_does_not_evict_held_lock():
+    registry = BoundedLockRegistry(max_capacity=2)
+
+    held = registry.get(("hiero", "sdk-js", 1))
+    await held.acquire()
+
+    unlocked = registry.get(("hiero", "sdk-js", 2))
+    replacement = registry.get(("hiero", "sdk-js", 3))
+
+    assert len(registry._locks) == 2
+    assert registry.get(("hiero", "sdk-js", 1)) is held
+    assert ("hiero", "sdk-js", 2) not in registry._locks
+    assert registry.get(("hiero", "sdk-js", 3)) is replacement
+    assert held.locked()
+    assert not unlocked.locked()
+
+    held.release()
+
+
+def test_bounded_lock_registry_refreshes_lru_order():
+    registry = BoundedLockRegistry(max_capacity=2)
+
+    first = registry.get(("hiero", "sdk-js", 1))
+    second = registry.get(("hiero", "sdk-js", 2))
+
+    assert registry.get(("hiero", "sdk-js", 1)) is first
+
+    third = registry.get(("hiero", "sdk-js", 3))
+
+    assert len(registry._locks) == 2
+    assert ("hiero", "sdk-js", 2) not in registry._locks
+    assert registry.get(("hiero", "sdk-js", 1)) is first
+    assert registry.get(("hiero", "sdk-js", 3)) is third
+
+
+def test_contributor_assign_lock_is_case_insensitive():
+    first = _get_contributor_assign_lock("hiero", "sdk-js", "Alice")
+    second = _get_contributor_assign_lock("hiero", "sdk-js", "alice")
+
+    assert first is second
+
+
+def test_bounded_lock_registry_stays_within_capacity_for_many_keys():
+    registry = BoundedLockRegistry(max_capacity=32)
+
+    for issue_number in range(5000):
+        registry.get(("hiero", "sdk-js", issue_number))
+
+    assert len(registry._locks) <= 32
+
+
 # ── CLA gate (#42: require_signed_cla) ────────────────────────
 
 
@@ -355,7 +435,6 @@ async def test_cla_gate_blocks_unsigned_contributor(mock_gh, ctx):
     mock_gh.get_file_content = AsyncMock(
         return_value=encode({"signedContributors": [{"name": "bob"}]})
     )
-
     wf = OnboardingWorkflow(mock_gh)
     await wf.handle_self_assign(ctx, make_payload())
 
@@ -375,7 +454,6 @@ async def test_cla_gate_allows_signed_contributor(mock_gh, ctx):
 
     wf = OnboardingWorkflow(mock_gh)
     await wf.handle_self_assign(ctx, make_payload())
-
     mock_gh.add_assignees.assert_awaited_once()
 
 

--- a/tests/unit/test_onboarding.py
+++ b/tests/unit/test_onboarding.py
@@ -346,6 +346,11 @@ async def test_account_check_failure_does_not_block_assignment(mock_gh, ctx):
 # ── Bounded lock registry (#101) ──────────────────────────────
 
 
+def test_bounded_lock_registry_rejects_invalid_capacity():
+    with pytest.raises(ValueError, match="max_capacity must be at least 1"):
+        BoundedLockRegistry(max_capacity=0)
+
+
 def test_bounded_lock_registry_reuses_lock_for_same_key():
     registry = BoundedLockRegistry(max_capacity=4)
 
@@ -356,7 +361,7 @@ def test_bounded_lock_registry_reuses_lock_for_same_key():
     assert len(registry._locks) == 1
 
 
-def test_bounded_lock_registry_evicts_oldest_unlocked_lock():
+def test_bounded_lock_registry_evicts_oldest_unused_entry():
     registry = BoundedLockRegistry(max_capacity=2)
 
     first = registry.get(("hiero", "sdk-js", 1))
@@ -375,20 +380,135 @@ def test_bounded_lock_registry_evicts_oldest_unlocked_lock():
 async def test_bounded_lock_registry_does_not_evict_held_lock():
     registry = BoundedLockRegistry(max_capacity=2)
 
-    held = registry.get(("hiero", "sdk-js", 1))
-    await held.acquire()
+    async with registry.get(("hiero", "sdk-js", 1)).acquire():
+        held = registry.get(("hiero", "sdk-js", 1))
+        registry.get(("hiero", "sdk-js", 2))
+        replacement = registry.get(("hiero", "sdk-js", 3))
 
-    unlocked = registry.get(("hiero", "sdk-js", 2))
-    replacement = registry.get(("hiero", "sdk-js", 3))
+        assert len(registry._locks) == 2
+        assert registry.get(("hiero", "sdk-js", 1)) is held
+        assert ("hiero", "sdk-js", 2) not in registry._locks
+        assert registry.get(("hiero", "sdk-js", 3)) is replacement
+        assert held.users == 1
 
-    assert len(registry._locks) == 2
-    assert registry.get(("hiero", "sdk-js", 1)) is held
-    assert ("hiero", "sdk-js", 2) not in registry._locks
-    assert registry.get(("hiero", "sdk-js", 3)) is replacement
-    assert held.locked()
-    assert not unlocked.locked()
 
-    held.release()
+@pytest.mark.asyncio
+async def test_bounded_lock_registry_does_not_evict_lock_with_waiter():
+    registry = BoundedLockRegistry(max_capacity=2)
+
+    first_key = ("hiero", "sdk-js", 1)
+    second_key = ("hiero", "sdk-js", 2)
+    third_key = ("hiero", "sdk-js", 3)
+
+    async with registry.get(first_key).acquire():
+        first = registry.get(first_key)
+        registry.get(second_key)
+
+        waiter_ready = asyncio.Event()
+        waiter_acquired = asyncio.Event()
+
+        async def wait_for_first():
+            waiter_ready.set()
+            async with registry.get(first_key).acquire():
+                waiter_acquired.set()
+
+        waiter = asyncio.create_task(wait_for_first())
+        await waiter_ready.wait()
+
+        while first.users != 2:
+            await asyncio.sleep(0)
+
+        replacement = registry.get(third_key)
+
+        assert len(registry._locks) == 2
+        assert registry.get(first_key) is first
+        assert second_key not in registry._locks
+        assert registry.get(third_key) is replacement
+        assert not waiter_acquired.is_set()
+        assert first.users == 2
+
+        await asyncio.sleep(0)
+        assert first.users == 2
+
+    await waiter
+
+    assert waiter_acquired.is_set()
+    assert first.users == 0
+
+
+@pytest.mark.asyncio
+async def test_bounded_lock_registry_removes_cancelled_waiter():
+    registry = BoundedLockRegistry(max_capacity=2)
+
+    first_key = ("hiero", "sdk-js", 1)
+    second_key = ("hiero", "sdk-js", 2)
+    third_key = ("hiero", "sdk-js", 3)
+
+    async with registry.get(first_key).acquire():
+        first = registry.get(first_key)
+        registry.get(second_key)
+
+        waiter_started = asyncio.Event()
+
+        async def wait_for_first():
+            waiter_started.set()
+            async with registry.get(first_key).acquire():
+                pass
+
+        waiter = asyncio.create_task(wait_for_first())
+        await waiter_started.wait()
+
+        while first.users != 2:
+            await asyncio.sleep(0)
+
+        waiter.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await waiter
+
+        assert first.users == 1
+
+        replacement = registry.get(third_key)
+
+        assert len(registry._locks) == 2
+        assert registry.get(first_key) is first
+        assert second_key not in registry._locks
+        assert registry.get(third_key) is replacement
+
+    assert first.users == 0
+
+
+@pytest.mark.asyncio
+async def test_bounded_lock_registry_releases_usage_after_exception():
+    registry = BoundedLockRegistry(max_capacity=1)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        async with registry.get(("hiero", "sdk-js", 1)).acquire():
+            first = registry.get(("hiero", "sdk-js", 1))
+            assert first.users == 1
+            raise RuntimeError("boom")
+
+    assert first.users == 0
+
+    replacement = registry.get(("hiero", "sdk-js", 2))
+
+    assert replacement is registry.get(("hiero", "sdk-js", 2))
+    assert ("hiero", "sdk-js", 1) not in registry._locks
+
+
+@pytest.mark.asyncio
+async def test_bounded_lock_registry_raises_when_all_locks_are_in_use():
+    registry = BoundedLockRegistry(max_capacity=2)
+
+    async with (
+        registry.get(("hiero", "sdk-js", 1)).acquire(),
+        registry.get(("hiero", "sdk-js", 2)).acquire(),
+    ):
+        with pytest.raises(
+            RuntimeError,
+            match="registry is at capacity and all locks are currently in use",
+        ):
+            registry.get(("hiero", "sdk-js", 3))
 
 
 def test_bounded_lock_registry_refreshes_lru_order():


### PR DESCRIPTION
## Summary

Fixes #101.

This change replaces the unbounded in-memory onboarding lock dictionaries with a bounded `BoundedLockRegistry` that uses LRU-style eviction.

### Changes

* Added `BoundedLockRegistry` using `OrderedDict`.
* Added a configurable maximum capacity.
* Reuses existing locks for the same key.
* Refreshes LRU order when a lock is accessed.
* Evicts the oldest **unheld** lock when capacity is reached.
* Never evicts a currently held lock.
* Raises an explicit error when the registry is full and all locks are held, preserving the strict capacity limit.
* Replaced both onboarding lock dictionaries with registries capped at 2048 entries.
* Added unit tests covering lock reuse, eviction, LRU behavior, held-lock protection, case-insensitive contributor locks, and large numbers of distinct keys.

### Testing

* `python -m pytest tests/unit/test_onboarding.py -vv`

  * **51 passed**
* `python -m pytest -vv`

  * **403 passed**

### Issue

Closes #101
