### PR TITLE
fix: purge expired database sessions periodically

### DIFF
--- a/app/auth/session.py
+++ b/app/auth/session.py
@@ -90,3 +90,16 @@ async def delete_db_session(db: AsyncSession, raw_session_id: str) -> None:
     await db.execute(stmt)
     await db.commit()
 
+
+async def purge_expired_sessions(db: AsyncSession) -> int:
+    """Delete all sessions whose expiration timestamp is in the past.
+
+    Returns:
+        int: Number of deleted expired session rows.
+    """
+    now = datetime.now(timezone.utc)
+    stmt = delete(Session).where(Session.expires_at <= now)
+    result = await db.execute(stmt)
+    await db.commit()
+    return result.rowcount or 0
+

--- a/app/scheduler/jobs.py
+++ b/app/scheduler/jobs.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 
+from app.auth.session import purge_expired_sessions
 from app.config.loader import ConfigLoader
 from app.db.database import AsyncSessionLocal
 from app.github.client import GitHubClient
@@ -68,6 +69,16 @@ class BotScheduler:
             CronTrigger(hour="*/6"),
             id="config_cache_flush",
             name="Config cache flush",
+            replace_existing=True,
+            coalesce=True,
+            max_instances=1,
+        )
+        # Session GC — runs daily at 03:00 UTC
+        self._scheduler.add_job(
+            self.run_session_gc,
+            CronTrigger(hour=3, minute=0),
+            id="session_gc",
+            name="Daily expired session garbage collection",
             replace_existing=True,
             coalesce=True,
             max_instances=1,
@@ -160,3 +171,9 @@ class BotScheduler:
     async def _flush_config_cache(self) -> None:
         self._config_loader.clear()
         log.debug("Config cache flushed")
+
+    async def run_session_gc(self) -> int:
+        async with AsyncSessionLocal() as db:
+            purged = await purge_expired_sessions(db)
+            log.info("Session GC completed: purged %d expired session(s)", purged)
+            return purged

--- a/app/scheduler/jobs.py
+++ b/app/scheduler/jobs.py
@@ -76,7 +76,7 @@ class BotScheduler:
         # Session GC — runs daily at 03:00 UTC
         self._scheduler.add_job(
             self.run_session_gc,
-            CronTrigger(hour=3, minute=0),
+            CronTrigger(hour=3, minute=0, timezone="UTC"),
             id="session_gc",
             name="Daily expired session garbage collection",
             replace_existing=True,

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -195,3 +195,12 @@ def test_start_registers_scheduler_jobs():
     assert session_gc_job["id"] == "session_gc"
     assert session_gc_job["coalesce"] is True
     assert session_gc_job["max_instances"] == 1
+
+    session_gc_call = mock_add_job.call_args_list[2]
+    assert session_gc_call.args[0] == scheduler.run_session_gc
+
+    trigger = session_gc_call.args[1]
+    fields = {field.name: field for field in trigger.fields}
+    assert fields["hour"].expressions[0].first == 3
+    assert fields["minute"].expressions[0].first == 0
+    assert str(trigger.timezone) == "UTC"

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -176,11 +176,12 @@ def test_start_registers_scheduler_jobs():
     ):
         scheduler.start()
 
-    assert mock_add_job.call_count == 2
+    assert mock_add_job.call_count == 3
     mock_start.assert_called_once()
 
     stale_job = mock_add_job.call_args_list[0].kwargs
     cache_job = mock_add_job.call_args_list[1].kwargs
+    session_gc_job = mock_add_job.call_args_list[2].kwargs
 
     assert stale_job["id"] == "stale_scan"
     assert stale_job["coalesce"] is True
@@ -190,3 +191,7 @@ def test_start_registers_scheduler_jobs():
     assert cache_job["id"] == "config_cache_flush"
     assert cache_job["coalesce"] is True
     assert cache_job["max_instances"] == 1
+
+    assert session_gc_job["id"] == "session_gc"
+    assert session_gc_job["coalesce"] is True
+    assert session_gc_job["max_instances"] == 1

--- a/tests/unit/test_session_gc.py
+++ b/tests/unit/test_session_gc.py
@@ -1,0 +1,60 @@
+# tests/unit/test_session_gc.py
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import select
+
+from app.auth.session import purge_expired_sessions
+from app.db.models import Session
+from app.scheduler.jobs import BotScheduler
+
+
+def make_session(session_id: str, user_id: int, expires_in: timedelta) -> Session:
+    return Session(
+        id=session_id,
+        user_id=user_id,
+        expires_at=datetime.now(timezone.utc) + expires_in,
+    )
+
+
+@pytest.mark.asyncio
+async def test_purge_deletes_only_expired_sessions(db):
+    db.add(make_session("expired-1", 1, timedelta(days=-1)))
+    db.add(make_session("expired-2", 1, timedelta(seconds=-1)))
+    db.add(make_session("active-1", 1, timedelta(days=7)))
+    await db.commit()
+
+    purged = await purge_expired_sessions(db)
+
+    assert purged == 2
+
+    remaining = (await db.execute(select(Session))).scalars().all()
+    assert [s.id for s in remaining] == ["active-1"]
+
+
+@pytest.mark.asyncio
+async def test_purge_returns_zero_when_nothing_expired(db):
+    db.add(make_session("active-1", 1, timedelta(days=7)))
+    await db.commit()
+
+    assert await purge_expired_sessions(db) == 0
+
+
+@pytest.mark.asyncio
+async def test_purge_is_a_noop_on_an_empty_table(db):
+    assert await purge_expired_sessions(db) == 0
+
+
+@pytest.mark.asyncio
+async def test_run_session_gc_delegates_to_purge_and_returns_count():
+    scheduler = BotScheduler(AsyncMock(), AsyncMock())
+
+    with patch("app.scheduler.jobs.purge_expired_sessions", AsyncMock(return_value=3)) as mock_purge:
+        purged = await scheduler.run_session_gc()
+
+    assert purged == 3
+    mock_purge.assert_awaited_once()

--- a/tests/unit/test_session_gc.py
+++ b/tests/unit/test_session_gc.py
@@ -37,6 +37,21 @@ async def test_purge_deletes_only_expired_sessions(db):
 
 
 @pytest.mark.asyncio
+async def test_purge_deletes_sessions_at_expiration_boundary(db):
+    boundary = datetime.now(timezone.utc)
+    db.add(
+        Session(
+            id="expired-at-boundary",
+            user_id=1,
+            expires_at=boundary,
+        )
+    )
+    await db.commit()
+
+    assert await purge_expired_sessions(db) == 1
+
+
+@pytest.mark.asyncio
 async def test_purge_returns_zero_when_nothing_expired(db):
     db.add(make_session("active-1", 1, timedelta(days=7)))
     await db.commit()


### PR DESCRIPTION
## Summary

`create_db_session()` stores sessions with a 7-day `expires_at`. `get_db_session()` already filters expired rows out of reads, and `delete_db_session()` removes a row on explicit logout, but nothing ever deletes an expired row that no one logs out of — closing the tab, clearing cookies, or switching devices leaves it behind forever, so the sessions table grows unbounded.

## Changes

* Add `purge_expired_sessions(db)` in `app/auth/session.py` — deletes all rows where `expires_at <= now` and returns the count deleted.
* Add `BotScheduler.run_session_gc()` in `app/scheduler/jobs.py` and register it as a daily cron job at 03:00 UTC, alongside the existing stale-scan and config-cache-flush jobs.
* Add `tests/unit/test_session_gc.py` covering deletion of expired sessions, retention of active ones, the empty/no-op case, and the scheduler delegating to the purge function.
* Update `tests/unit/test_scheduler.py`'s job-registration test for the new job count (2 → 3).

## Testing

* `python -m pytest` — 496 passed
* `ruff check .` / `mypy app/` — no new findings introduced (both tools' pre-existing unrelated findings are unchanged from `main`)

Closes #99